### PR TITLE
feat: add csvURL and csvData props

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,20 @@ export default function Page() {
     </main>
   );
 }
+
+// Load from a remote file
+// <ReactTableCSV csvURL="/path/to/data.csv" />
+
+// Or pass pre-parsed PapaParse output
+// const parsed = Papa.parse(csvText, { header: true });
+// <ReactTableCSV csvData={parsed} />
 ```
 
 ## Props
-- `csvString: string` CSV text to render. Required.
+- `csvString?: string` CSV text to render.
+- `csvURL?: string` URL to fetch CSV data from.
+- `csvData?: object` Result of `Papa.parse` (`{ data, meta: { fields } }`) to use directly.
+  One of `csvString`, `csvURL`, or `csvData` must be provided.
 - `downloadFilename?: string` Filename for exports. Default `"data.csv"`.
 - `storageKey?: string` localStorage key for settings. Default `"react-table-csv-key"`.
 - `defaultSettings?: string` JSON string (same schema as exported) used as defaults and fallback if localStorage is missing/corrupt.

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -4,7 +4,10 @@
 React Table CSV is a React component for viewing and manipulating CSV data in-browser. It offers filtering, sorting, grouping, column management, styling, and export utilities to explore structured datasets without a backend.
 
 ## Props
-- **csvString** (`string`): CSV content to render. Defaults to an embedded sample dataset.
+- **csvString** (`string`, optional): CSV content to render.
+- **csvURL** (`string`, optional): URL to fetch CSV data from.
+- **csvData** (`object`, optional): Result of PapaParse (`{ data, meta: { fields } }`) to use directly.
+  One of `csvString`, `csvURL`, or `csvData` must be supplied.
 - **downloadFilename** (`string`): Suggested filename for exported CSV downloads.
 - **storageKey** (`string`): `localStorage` key used for persisting user settings.
 - **defaultSettings** (`string`): Optional JSON string with initial settings to apply on load.


### PR DESCRIPTION
## Summary
- support `csvURL` and `csvData` props for remote and pre-parsed CSV sources
- document new data source options

## Testing
- `cd demo && npm run dev`
- `npm run build`
- `npm run lint`
- `cd demo && npm run lint` *(fails: Unexpected token in .eslintrc.json)*
- `npm test`
- `npm pack --dry-run`


------
https://chatgpt.com/codex/tasks/task_e_689d2c00a4a48323b8360d44091b7930