### PR TITLE
feat: add popular color themes

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A React component for exploring CSV data with a rich, spreadsheet‑like UI. It 
 - Split tables by selected columns (one table per unique combination) with filters rendered on the first split table.
 - Row numbers (resets per table) and stable internal row IDs for React keys.
 - Settings: export/import JSON, autosave to `localStorage`, Copy URL with embedded `defaultSetting` query param.
-- Light and dark themes using local CSS Modules (no Tailwind dependency).
+- Light, dark, Solarized, Dracula, Monokai, and Gruvbox themes using local CSS Modules (no Tailwind dependency).
 
 ## Using the Component in Your App
 
@@ -55,7 +55,7 @@ export default function Page() {
 - `downloadFilename?: string` Filename for exports. Default `"data.csv"`.
 - `storageKey?: string` localStorage key for settings. Default `"react-table-csv-key"`.
 - `defaultSettings?: string` JSON string (same schema as exported) used as defaults and fallback if localStorage is missing/corrupt.
-- `theme?: 'lite' | 'dark'` Visual theme for the component. Default `"lite"`.
+- `theme?: 'lite' | 'dark' | 'solarized' | 'dracula' | 'monokai' | 'gruvbox'` Visual theme for the component. Default `"lite"`.
 
 ## Exported/Imported Settings (high‑level)
 - `{ version, columnStyles, columnOrder, hiddenColumns, filters, dropdownFilters, filterMode, showFilterRow, pinnedAnchor, showRowNumbers, customize }`

--- a/index.d.ts
+++ b/index.d.ts
@@ -7,7 +7,7 @@ export interface ReactTableCSVProps {
   downloadFilename?: string;
   storageKey?: string;
   defaultSettings?: string | null;
-  theme?: string;
+  theme?: 'lite' | 'dark' | 'solarized' | 'dracula' | 'monokai' | 'gruvbox';
 }
 
 export const ReactTableCSV: React.FC<ReactTableCSVProps>;

--- a/src/ReactTableCsv.jsx
+++ b/src/ReactTableCsv.jsx
@@ -1107,7 +1107,7 @@ const ReactTableCSV = ({ csvString, csvURL, csvData, downloadFilename = 'data.cs
   }
 
   return (
-    <div className={`${styles.root} ${theme === 'dark' ? styles.dark : styles.lite}`}>
+    <div className={`${styles.root} ${styles[theme] || styles.lite}`}>
       <div className={styles.container}>
         <div className={styles.card}>
           {/* <div className={styles.header}>

--- a/src/ReactTableCsv.module.css
+++ b/src/ReactTableCsv.module.css
@@ -35,6 +35,74 @@
   --filter-bg: #374151;
 }
 
+.solarized {
+  --bg: #002b36;
+  --surface: #073642;
+  --surface-alt: #002b36;
+  --row-hover: #586e75;
+  --text: #fdf6e3;
+  --muted: #839496;
+  --border: #073642;
+  --primary: #268bd2;
+  --accent: #d33682;
+  --danger: #dc322f;
+  --thead: #073642;
+  --control-bg: #073642;
+  --btn-text: #fdf6e3;
+  --filter-bg: #073642;
+}
+
+.dracula {
+  --bg: #282a36;
+  --surface: #44475a;
+  --surface-alt: #383a59;
+  --row-hover: #6272a4;
+  --text: #f8f8f2;
+  --muted: #6272a4;
+  --border: #44475a;
+  --primary: #bd93f9;
+  --accent: #ff79c6;
+  --danger: #ff5555;
+  --thead: #21222c;
+  --control-bg: #44475a;
+  --btn-text: #f8f8f2;
+  --filter-bg: #44475a;
+}
+
+.monokai {
+  --bg: #272822;
+  --surface: #3e3d32;
+  --surface-alt: #2e2d2a;
+  --row-hover: #49483e;
+  --text: #f8f8f2;
+  --muted: #75715e;
+  --border: #3e3d32;
+  --primary: #a6e22e;
+  --accent: #66d9ef;
+  --danger: #f92672;
+  --thead: #49483e;
+  --control-bg: #3e3d32;
+  --btn-text: #f8f8f2;
+  --filter-bg: #3e3d32;
+}
+
+.gruvbox {
+  --bg: #282828;
+  --surface: #3c3836;
+  --surface-alt: #32302f;
+  --row-hover: #504945;
+  --text: #ebdbb2;
+  --muted: #a89984;
+  --border: #3c3836;
+  --primary: #d79921;
+  --accent: #d3869b;
+  --danger: #cc241d;
+  --thead: #3c3836;
+  --control-bg: #3c3836;
+  --btn-text: #ebdbb2;
+  --filter-bg: #3c3836;
+}
+
 .root {
   min-height: 100vh;
   padding: 4px;


### PR DESCRIPTION
## Summary
- add Solarized, Dracula, Monokai, and Gruvbox theme variables
- choose theme dynamically based on `theme` prop
- document and type new theme options

## Testing
- `npm run build`
- `npm run lint`
- `npm test`
- `npm pack --dry-run`
- `cd demo && npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689dab740760832396d5712884ce7e33