### PR TITLE
Add Jest test for ReactTableCSV component

### DIFF
--- a/.babelrc.json
+++ b/.babelrc.json
@@ -8,5 +8,13 @@
       }
     ],
     ["@babel/preset-react", { "runtime": "automatic" }]
-  ]
+  ],
+  "env": {
+    "test": {
+      "presets": [
+        ["@babel/preset-env", { "targets": { "node": "current" } }],
+        ["@babel/preset-react", { "runtime": "automatic" }]
+      ]
+    }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -56,12 +56,27 @@
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-react": "^7.35.0",
-    "rimraf": "^5.0.0"
+    "rimraf": "^5.0.0",
+    "@testing-library/react": "^14.0.0",
+    "@testing-library/jest-dom": "^6.4.2",
+    "@testing-library/user-event": "^14.5.2",
+    "jest": "^29.7.0",
+    "babel-jest": "^29.7.0",
+    "identity-obj-proxy": "^3.0.0"
   },
   "scripts": {
     "build": "rimraf dist && babel src --extensions .js,.jsx,.ts,.tsx --out-dir dist --copy-files",
     "prepare": "npm run build",
     "lint": "eslint src --ext .js,.jsx,.ts,.tsx",
-    "test": "echo 'No tests yet'"
+    "test": "jest"
+  },
+  "jest": {
+    "testEnvironment": "jsdom",
+    "transform": {
+      "^.+\\.[tj]sx?$": "babel-jest"
+    },
+    "moduleNameMapper": {
+      "\\.(css|less|sass|scss)$": "identity-obj-proxy"
+    }
   }
 }

--- a/src/__tests__/ReactTableCsv.test.jsx
+++ b/src/__tests__/ReactTableCsv.test.jsx
@@ -1,0 +1,23 @@
+/* eslint-env jest */
+import '@testing-library/jest-dom';
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import ReactTableCSV from '../ReactTableCsv';
+
+describe('ReactTableCSV', () => {
+  it('renders row and column info', () => {
+    const csvData = {
+      headers: ['id', 'name'],
+      data: [
+        { id: 1, name: 'Alice' },
+        { id: 2, name: 'Bob' }
+      ]
+    };
+
+    render(<ReactTableCSV csvData={csvData} />);
+
+    expect(
+      screen.getByText('Showing 2 of 2 rows | 2 of 2 columns')
+    ).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- configure Babel for Jest test environment
- add Jest, Testing Library, and related dev dependencies
- create initial render test for `ReactTableCSV`

## Testing
- `npm run build`
- `npm run lint`
- `npm test` *(fails: jest: not found)*
- `npm pack --dry-run`
- `cd demo && npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689dc1c61c9c8323a530f2f7decdb46b