### PR TITLE
fix: adjust column reordering index

### DIFF
--- a/src/ReactTableCsv.jsx
+++ b/src/ReactTableCsv.jsx
@@ -267,8 +267,11 @@ const ReactTableCSV = ({ csvString, csvURL, csvData, downloadFilename = 'data.cs
     if (draggedColumn && draggedColumn !== targetHeader) {
       const newOrder = [...columnOrder];
       const draggedIndex = newOrder.indexOf(draggedColumn);
-      const targetIndex = newOrder.indexOf(targetHeader);
-      
+      let targetIndex = newOrder.indexOf(targetHeader);
+      if (draggedIndex < targetIndex) {
+        targetIndex -= 1;
+      }
+
       // Remove dragged column and insert at target position
       newOrder.splice(draggedIndex, 1);
       newOrder.splice(targetIndex, 0, draggedColumn);


### PR DESCRIPTION
## Summary
- fix column drag-and-drop reordering to account for index shift when dragging right

## Testing
- `npm run build`
- `npm run lint`
- `npm test`
- `npm pack --dry-run`
- `cd demo && npm run lint`
- `cd demo && npm run dev` *(fails: no UI in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_689e9145822c8323b8231fee3dd5761e