### PR TITLE
feat: persist theme in settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ export default function Page() {
         downloadFilename="data.csv"
         storageKey="react-table-csv-key"
         defaultSettings=""
-        theme="dark"
       />
     </main>
   );
@@ -55,10 +54,10 @@ export default function Page() {
 - `downloadFilename?: string` Filename for exports. Default `"data.csv"`.
 - `storageKey?: string` localStorage key for settings. Default `"react-table-csv-key"`.
 - `defaultSettings?: string` JSON string (same schema as exported) used as defaults and fallback if localStorage is missing/corrupt.
-- `theme?: 'lite' | 'dark' | 'solarized' | 'dracula' | 'monokai' | 'gruvbox'` Visual theme for the component. Default `"lite"`.
+- Theme selection is managed inside the component's settings. Use the Settings panel to cycle themes; the current theme is saved to `localStorage` and included when exporting settings.
 
 ## Exported/Imported Settings (high‑level)
-- `{ version, columnStyles, columnOrder, hiddenColumns, filters, dropdownFilters, filterMode, showFilterRow, pinnedAnchor, showRowNumbers, customize }`
+- `{ version, theme, columnStyles, columnOrder, hiddenColumns, filters, dropdownFilters, filterMode, showFilterRow, pinnedAnchor, showRowNumbers, customize }`
 
 ## Development
 See the [CONTRIBUTING.md](./CONTRIBUTING.md) file for details.

--- a/demo/src/App.jsx
+++ b/demo/src/App.jsx
@@ -5,13 +5,13 @@ import { sampleCSV } from "./sample-csv";
 
 
 function App() {
-  const sampleSettings = '{"version":"0.1","columnStyles":{"Department":{"splitBy":true,"type":"number"},"Position":{"groupBy":true},"Name":{"reducer":"cnt"},"Salary":{"reducer":"min-max","type":"number"},"Start Date":{"reducer":"min-max"},"Performance Rating":{"reducer":"min-max"}},"columnOrder":["Department","Position","Name","Salary","Start Date","Performance Rating"],"hiddenColumns":["Department"],"filters":{"Salary":">60000","Position":""},"dropdownFilters":{},"filterMode":{"Salary":"text"},"showFilterRow":false,"pinnedAnchor":null,"showRowNumbers":true}';
+  const sampleSettings = '{"version":"0.1","theme":"dark","columnStyles":{"Department":{"splitBy":true,"type":"number"},"Position":{"groupBy":true},"Name":{"reducer":"cnt"},"Salary":{"reducer":"min-max","type":"number"},"Start Date":{"reducer":"min-max"},"Performance Rating":{"reducer":"min-max"}},"columnOrder":["Department","Position","Name","Salary","Start Date","Performance Rating"],"hiddenColumns":["Department"],"filters":{"Salary":">60000","Position":""},"dropdownFilters":{},"filterMode":{"Salary":"text"},"showFilterRow":false,"pinnedAnchor":null,"showRowNumbers":true}';
 
   return (
     <>
       <h1>@poserjs/react-table-csv</h1>
       <div>
-        <ReactTableCSV csvString={sampleCSV} defaultSettings={sampleSettings} theme="dark"/>
+        <ReactTableCSV csvString={sampleCSV} defaultSettings={sampleSettings}/>
       </div>
     </>
   )

--- a/index.d.ts
+++ b/index.d.ts
@@ -7,7 +7,6 @@ export interface ReactTableCSVProps {
   downloadFilename?: string;
   storageKey?: string;
   defaultSettings?: string | null;
-  theme?: 'lite' | 'dark' | 'solarized' | 'dracula' | 'monokai' | 'gruvbox';
 }
 
 export const ReactTableCSV: React.FC<ReactTableCSVProps>;

--- a/src/ReactTableCsv.jsx
+++ b/src/ReactTableCsv.jsx
@@ -93,7 +93,7 @@ const FilterDropdown = ({ values, selectedValues, onSelectionChange, onClose }) 
 const SETTINGS_VERSION = '0.1';
 const THEMES = ['lite', 'dark', 'solarized', 'dracula', 'monokai', 'gruvbox'];
 
-const ReactTableCSV = ({ csvString, csvURL, csvData, downloadFilename = 'data.csv', storageKey = 'react-table-csv-key', defaultSettings = '', theme = 'lite' }) => {
+const ReactTableCSV = ({ csvString, csvURL, csvData, downloadFilename = 'data.csv', storageKey = 'react-table-csv-key', defaultSettings = '' }) => {
   // Parse CSV using PapaParse for robust handling (quotes, commas, BOM)
   const parseCSV = (csv) => {
     const result = Papa.parse(csv, {
@@ -134,7 +134,7 @@ const ReactTableCSV = ({ csvString, csvURL, csvData, downloadFilename = 'data.cs
   const [originalHeaders, setOriginalHeaders] = useState([]);
   const [data, setData] = useState([]);
   const [error, setError] = useState('');
-  const [currentTheme, setCurrentTheme] = useState(theme);
+  const [currentTheme, setCurrentTheme] = useState('lite');
 
   const cycleTheme = () => {
     const idx = THEMES.indexOf(currentTheme);
@@ -852,6 +852,7 @@ const ReactTableCSV = ({ csvString, csvURL, csvData, downloadFilename = 'data.cs
     });
     return {
       version: SETTINGS_VERSION,
+      theme: currentTheme,
       columnStyles,
       columnOrder,
       hiddenColumns: Array.from(hiddenColumns),
@@ -863,7 +864,7 @@ const ReactTableCSV = ({ csvString, csvURL, csvData, downloadFilename = 'data.cs
       showRowNumbers,
       customize: customize,
     };
-  }, [columnStyles, columnOrder, hiddenColumns, filters, dropdownFilters, filterMode, showFilterRow, pinnedAnchor, showRowNumbers, customize]);
+  }, [columnStyles, columnOrder, hiddenColumns, filters, dropdownFilters, filterMode, showFilterRow, pinnedAnchor, showRowNumbers, customize, currentTheme]);
 
   const applySettings = useCallback((s) => {
     try {
@@ -884,6 +885,7 @@ const ReactTableCSV = ({ csvString, csvURL, csvData, downloadFilename = 'data.cs
       if (typeof s.pinnedAnchor === 'string' || s.pinnedAnchor === null) setPinnedAnchor(s.pinnedAnchor);
       if (typeof s.showRowNumbers === 'boolean') setShowRowNumbers(s.showRowNumbers);
       if (typeof s.customize === 'boolean') setCustomize(s.customize);
+      if (typeof s.theme === 'string') setCurrentTheme(s.theme);
       // backward-compat: older settings may use `editable`
       if (typeof s.editable === 'boolean' && typeof s.customize !== 'boolean') setCustomize(s.editable);
     } catch {
@@ -934,6 +936,7 @@ const ReactTableCSV = ({ csvString, csvURL, csvData, downloadFilename = 'data.cs
     pinnedAnchor,
     showRowNumbers,
     customize,
+    currentTheme,
     storageKey,
     buildSettings,
   ]);
@@ -977,6 +980,7 @@ const ReactTableCSV = ({ csvString, csvURL, csvData, downloadFilename = 'data.cs
       setShowFilterRow(false);
       setPinnedAnchor(null);
       setShowRowNumbers(false);
+      setCurrentTheme('lite');
       try { window.localStorage.removeItem(storageKey); } catch { /* ignore */ }
     }
   };

--- a/src/__tests__/ReactTableCsv.test.jsx
+++ b/src/__tests__/ReactTableCsv.test.jsx
@@ -1,7 +1,7 @@
 /* eslint-env jest */
 import '@testing-library/jest-dom';
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import ReactTableCSV from '../ReactTableCsv';
 
 describe('ReactTableCSV', () => {
@@ -19,5 +19,28 @@ describe('ReactTableCSV', () => {
     expect(
       screen.getByText('Showing 2 of 2 rows | 2 of 2 columns')
     ).toBeInTheDocument();
+  });
+
+  it('saves theme changes to localStorage', async () => {
+    const storageKey = 'theme-test';
+    window.localStorage.removeItem(storageKey);
+    const csvData = {
+      headers: ['id', 'name'],
+      data: [
+        { id: 1, name: 'Alice' },
+      ]
+    };
+
+    render(<ReactTableCSV csvData={csvData} storageKey={storageKey} />);
+
+    fireEvent.click(screen.getByText('Customize'));
+    fireEvent.click(screen.getByText('Settings'));
+    fireEvent.click(screen.getByText(/Theme:/));
+
+    await waitFor(() => {
+      const saved = JSON.parse(window.localStorage.getItem(storageKey) || '{}');
+      expect(saved.theme).toBeDefined();
+      expect(saved.theme).toBe('dark');
+    });
   });
 });


### PR DESCRIPTION
## Summary
- move theme into saved settings and cycle button persists to localStorage
- document theme persistence and remove the theme prop
- demo and tests updated for settings-based theme

## Testing
- `npm run build`
- `npm run lint`
- `npm test`
- `npm pack --dry-run`
- `cd demo && npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689e9a97e8488323af96de969379c261