### PR TITLE
refactor: extract CSV parsing into hook

### DIFF
--- a/src/ReactTableCsv.jsx
+++ b/src/ReactTableCsv.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useMemo, useEffect, useRef, useCallback, useLayoutEffect } from 'react';
 import Papa from 'papaparse';
+import useCsvData from './hooks/useCsvData';
 import { ChevronUp, ChevronDown, Filter, X, Type, AlignLeft, AlignCenter, AlignRight, Columns, Search, List, WrapText, Eye, EyeOff, GripVertical, Paintbrush, Pin, PinOff, Download, Copy, Scissors, Hash, RefreshCw, SunMoon, Settings as SettingsIcon } from 'lucide-react';
 import styles from './ReactTableCsv.module.css';
 
@@ -94,46 +95,7 @@ const SETTINGS_VERSION = '0.1';
 const THEMES = ['lite', 'dark', 'solarized', 'dracula', 'monokai', 'gruvbox'];
 
 const ReactTableCSV = ({ csvString, csvURL, csvData, downloadFilename = 'data.csv', storageKey = 'react-table-csv-key', defaultSettings = '' }) => {
-  // Parse CSV using PapaParse for robust handling (quotes, commas, BOM)
-  const parseCSV = (csv) => {
-    const result = Papa.parse(csv, {
-      header: true,
-      skipEmptyLines: true,
-      dynamicTyping: true,
-      transformHeader: (h) => (h || '').trim(),
-      transform: (v) => (typeof v === 'string' ? v.trim() : v),
-    });
-
-    const headers = result.meta?.fields || [];
-    const data = (result.data || []).map((row, idx) => {
-      const obj = {};
-      headers.forEach((h) => {
-        obj[h] = row[h] !== undefined && row[h] !== null ? row[h] : '';
-      });
-      // assign stable internal id starting from 1
-      obj._id = idx + 1;
-      return obj;
-    });
-    return { headers, data };
-  };
-
-  const normalizeParsed = (parsed) => {
-    const headers = parsed?.meta?.fields || parsed?.headers || [];
-    const rows = parsed?.data || [];
-    const data = rows.map((row, idx) => {
-      const obj = {};
-      headers.forEach((h) => {
-        obj[h] = row[h] !== undefined && row[h] !== null ? row[h] : '';
-      });
-      obj._id = idx + 1;
-      return obj;
-    });
-    return { headers, data };
-  };
-
-  const [originalHeaders, setOriginalHeaders] = useState([]);
-  const [data, setData] = useState([]);
-  const [error, setError] = useState('');
+  const { originalHeaders, data, error } = useCsvData({ csvString, csvURL, csvData });
   const [currentTheme, setCurrentTheme] = useState('lite');
 
   const cycleTheme = () => {
@@ -141,39 +103,6 @@ const ReactTableCSV = ({ csvString, csvURL, csvData, downloadFilename = 'data.cs
     const next = THEMES[(idx + 1) % THEMES.length];
     setCurrentTheme(next);
   };
-
-  useEffect(() => {
-    const controller = new AbortController();
-    const loadData = async () => {
-      try {
-        if (csvString) {
-          const { headers, data } = parseCSV(csvString);
-          setOriginalHeaders(headers);
-          setData(data);
-        } else if (csvData) {
-          const { headers, data } = normalizeParsed(csvData);
-          setOriginalHeaders(headers);
-          setData(data);
-        } else if (csvURL) {
-          const res = await fetch(csvURL, { signal: controller.signal });
-          const text = await res.text();
-          if (controller.signal.aborted) return;
-          const { headers, data } = parseCSV(text);
-          if (controller.signal.aborted) return;
-          setOriginalHeaders(headers);
-          setData(data);
-        } else {
-          setError('One of csvString, csvData, or csvURL must be provided.');
-        }
-      } catch (err) {
-        if (err.name !== 'AbortError') {
-          setError('Failed to load CSV data.');
-        }
-      }
-    };
-    loadData();
-    return () => controller.abort();
-  }, [csvString, csvData, csvURL]);
 
   // State management
   // Per-column sorting is configured via columnStyles[col].sort:

--- a/src/hooks/useCsvData.js
+++ b/src/hooks/useCsvData.js
@@ -1,0 +1,81 @@
+import { useState, useEffect } from 'react';
+import Papa from 'papaparse';
+
+const useCsvData = ({ csvString, csvURL, csvData }) => {
+  const parseCSV = (csv) => {
+    const result = Papa.parse(csv, {
+      header: true,
+      skipEmptyLines: true,
+      dynamicTyping: true,
+      transformHeader: (h) => (h || '').trim(),
+      transform: (v) => (typeof v === 'string' ? v.trim() : v),
+    });
+
+    const headers = result.meta?.fields || [];
+    const data = (result.data || []).map((row, idx) => {
+      const obj = {};
+      headers.forEach((h) => {
+        obj[h] = row[h] !== undefined && row[h] !== null ? row[h] : '';
+      });
+      obj._id = idx + 1;
+      return obj;
+    });
+    return { headers, data };
+  };
+
+  const normalizeParsed = (parsed) => {
+    const headers = parsed?.meta?.fields || parsed?.headers || [];
+    const rows = parsed?.data || [];
+    const data = rows.map((row, idx) => {
+      const obj = {};
+      headers.forEach((h) => {
+        obj[h] = row[h] !== undefined && row[h] !== null ? row[h] : '';
+      });
+      obj._id = idx + 1;
+      return obj;
+    });
+    return { headers, data };
+  };
+
+  const [originalHeaders, setOriginalHeaders] = useState([]);
+  const [data, setData] = useState([]);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    const controller = new AbortController();
+    const loadData = async () => {
+      try {
+        setError('');
+        if (csvString) {
+          const { headers, data } = parseCSV(csvString);
+          setOriginalHeaders(headers);
+          setData(data);
+        } else if (csvData) {
+          const { headers, data } = normalizeParsed(csvData);
+          setOriginalHeaders(headers);
+          setData(data);
+        } else if (csvURL) {
+          const res = await fetch(csvURL, { signal: controller.signal });
+          const text = await res.text();
+          if (controller.signal.aborted) return;
+          const { headers, data } = parseCSV(text);
+          if (controller.signal.aborted) return;
+          setOriginalHeaders(headers);
+          setData(data);
+        } else {
+          setError('One of csvString, csvData, or csvURL must be provided.');
+        }
+      } catch (err) {
+        if (err.name !== 'AbortError') {
+          setError('Failed to load CSV data.');
+        }
+      }
+    };
+    loadData();
+    return () => controller.abort();
+  }, [csvString, csvData, csvURL]);
+
+  return { originalHeaders, data, error };
+};
+
+export default useCsvData;


### PR DESCRIPTION
## Summary
- factor out CSV parsing and normalization into reusable `useCsvData` hook
- simplify `ReactTableCSV` by consuming `useCsvData`

## Testing
- `npm run build`
- `npm run lint`
- `npm test`
- `npm pack --dry-run`
- `cd demo && npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689e9f9a6a6c8323aa4a7d9df2dc6693