### PR TITLE
fix(demo): fit page height to table content

### DIFF
--- a/demo/src/index.css
+++ b/demo/src/index.css
@@ -24,10 +24,7 @@ a:hover {
 
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
   min-width: 320px;
-  min-height: 100vh;
 }
 
 h1 {


### PR DESCRIPTION
## Summary
- avoid forcing demo body to viewport height so page only fits table content

## Testing
- `npm run build`
- `npm run lint`
- `npm test`
- `npm pack --dry-run`
- `cd demo && npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689eb7063e808323b71e7cd530a604b7