### PR TITLE
fix: handle null cell values in filter

### DIFF
--- a/src/__tests__/DataTable.filter.test.jsx
+++ b/src/__tests__/DataTable.filter.test.jsx
@@ -1,0 +1,42 @@
+/* eslint-env jest */
+import '@testing-library/jest-dom';
+import React from 'react';
+import { render } from '@testing-library/react';
+import DataTable from '../components/DataTable';
+
+describe('DataTable filtering', () => {
+  it('handles null and undefined values without throwing', () => {
+    const props = {
+      data: [
+        { id: null, name: 'Alice' },
+        { id: undefined, name: 'Bob' },
+        { id: 3, name: 'Carl' }
+      ],
+      originalHeaders: ['id', 'name'],
+      columnStyles: {},
+      columnOrder: ['id', 'name'],
+      setColumnOrder: jest.fn(),
+      hiddenColumns: new Set(),
+      filters: { id: '3' },
+      setFilters: jest.fn(),
+      filterMode: {},
+      setFilterMode: jest.fn(),
+      dropdownFilters: {},
+      setDropdownFilters: jest.fn(),
+      showFilterRow: true,
+      showRowNumbers: false,
+      isCustomize: false,
+      selectedColumn: null,
+      setSelectedColumn: jest.fn(),
+      showStylePanel: false,
+      setShowStylePanel: jest.fn(),
+      updateColumnStyle: jest.fn(),
+      toggleColumnVisibility: jest.fn(),
+      pinnedAnchor: null,
+      setPinnedAnchor: jest.fn(),
+      onDataProcessed: jest.fn(),
+    };
+
+    expect(() => render(<DataTable {...props} />)).not.toThrow();
+  });
+});

--- a/src/components/DataTable.jsx
+++ b/src/components/DataTable.jsx
@@ -259,7 +259,7 @@ const DataTable = ({
         const declaredType = columnStyles[key]?.type || 'auto';
         const mode = declaredType === 'number' ? 'number' : (declaredType === 'text' ? 'text' : (typeof r === 'number' ? 'number' : 'text'));
         if (!parsed) {
-          return r?.toString().toLowerCase().includes(String(value).toLowerCase());
+          return String(r ?? "").toLowerCase().includes(String(value).toLowerCase());
         }
         const { op, rhs } = parsed;
         return cmp(op, r, rhs, mode);


### PR DESCRIPTION
## Summary
- prevent filter from throwing on null or undefined cell values
- test filtering to ensure empty cells are handled safely

## Testing
- `npm run build`
- `npm run lint`
- `npm test`
- `npm pack --dry-run`
- `cd demo && npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689edae181008323b6a926d962d46b25