### PR TITLE
fix: reset customize flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,9 @@ export default function Page() {
 ## Exported/Imported Settings (high‑level)
 - `{ version, theme, columnStyles, columnOrder, hiddenColumns, filters, dropdownFilters, filterMode, showFilterRow, pinnedAnchor, showRowNumbers, customize }`
 
+## Resetting Settings
+Call `resetSettings()` to revert the table to its initial configuration. The reset also turns off customize mode (or respects a `customize` value from provided defaults) and returns the applied settings object.
+
 ## Development
 See the [CONTRIBUTING.md](./CONTRIBUTING.md) file for details.
 

--- a/src/__tests__/ReactTableCsv.test.jsx
+++ b/src/__tests__/ReactTableCsv.test.jsx
@@ -43,4 +43,32 @@ describe('ReactTableCSV', () => {
       expect(saved.theme).toBe('dark');
     });
   });
+
+  it('resets toggles to default values', () => {
+    const csvData = {
+      headers: ['id', 'name'],
+      data: [
+        { id: 1, name: 'Alice' },
+      ],
+    };
+
+    render(<ReactTableCSV csvData={csvData} />);
+
+    const customizeCheckbox = screen.getByLabelText('Customize');
+    fireEvent.click(customizeCheckbox);
+
+    fireEvent.click(screen.getByText('Show Filters'));
+    fireEvent.click(screen.getByText('Settings'));
+
+    fireEvent.click(screen.getByText('Reset Settings'));
+
+    expect(customizeCheckbox).not.toBeChecked();
+
+    fireEvent.click(customizeCheckbox);
+
+    expect(screen.getByText('Show Filters')).toBeInTheDocument();
+    expect(screen.queryByText('Hide Filters')).not.toBeInTheDocument();
+    expect(screen.getByText('Settings')).toBeInTheDocument();
+    expect(screen.queryByText('Hide Settings')).not.toBeInTheDocument();
+  });
 });

--- a/src/hooks/useTableState.js
+++ b/src/hooks/useTableState.js
@@ -217,33 +217,38 @@ const useTableState = ({
   ]);
 
   const resetSettings = () => {
-    if (defaultSettingsObj) {
-      applySettings(defaultSettingsObj);
-      try {
-        window.localStorage.setItem(
-          storageKey,
-          JSON.stringify(defaultSettingsObj)
-        );
-      } catch {
-        /* ignore */
-      }
-    } else {
-      setColumnStyles({});
-      setColumnOrder(originalHeaders);
-      setHiddenColumns(new Set());
-      setFilters({});
-      setDropdownFilters({});
-      setFilterMode({});
-      setShowFilterRow(false);
-      setPinnedAnchor(null);
-      setShowRowNumbers(false);
-      setCurrentTheme('lite');
-      try {
+    const initial = defaultSettingsObj
+      ? { ...defaultSettingsObj }
+      : {
+          columnStyles: {},
+          columnOrder: originalHeaders,
+          hiddenColumns: [],
+          filters: {},
+          dropdownFilters: {},
+          filterMode: {},
+          showFilterRow: false,
+          pinnedAnchor: null,
+          showRowNumbers: false,
+          theme: 'lite',
+          customize: false,
+        };
+
+    if (typeof initial.customize !== 'boolean') initial.customize = false;
+
+    applySettings(initial);
+    setShowStylePanel(false);
+
+    try {
+      if (defaultSettingsObj) {
+        window.localStorage.setItem(storageKey, JSON.stringify(initial));
+      } else {
         window.localStorage.removeItem(storageKey);
-      } catch {
-        /* ignore */
       }
+    } catch {
+      /* ignore */
     }
+
+    return initial;
   };
 
   return {


### PR DESCRIPTION
## Summary
- ensure resetSettings returns initial settings with customize flag
- document resetSettings behavior
- test resetting toggles to defaults

## Testing
- `npm run build`
- `npm run lint`
- `npm test`
- `npm pack --dry-run`
- `cd demo && npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689edae85b0c83238a1f8f43d6310d90