### PR TITLE
fix: restore visibility for new CSV columns

### DIFF
--- a/src/hooks/useTableState.js
+++ b/src/hooks/useTableState.js
@@ -144,8 +144,13 @@ const useTableState = ({
       try {
         if (!s || typeof s !== 'object') return;
         if (s.columnStyles) setColumnStyles(s.columnStyles);
-        if (Array.isArray(s.columnOrder))
-          setColumnOrder(s.columnOrder.filter((h) => originalHeaders.includes(h)));
+        if (Array.isArray(s.columnOrder)) {
+          const filtered = s.columnOrder.filter((h) =>
+            originalHeaders.includes(h)
+          );
+          const missing = originalHeaders.filter((h) => !filtered.includes(h));
+          setColumnOrder([...filtered, ...missing]);
+        }
         if (Array.isArray(s.hiddenColumns))
           setHiddenColumns(new Set(s.hiddenColumns.filter((h) => originalHeaders.includes(h))));
         if (s.filters && typeof s.filters === 'object') setFilters(s.filters);

--- a/src/hooks/useTableState.test.js
+++ b/src/hooks/useTableState.test.js
@@ -1,0 +1,33 @@
+/* eslint-env jest */
+import { renderHook, act } from '@testing-library/react';
+import useTableState from './useTableState';
+
+describe('applySettings', () => {
+  it('appends new headers to columnOrder when saved settings are missing them', () => {
+    const saved = { columnOrder: ['b', 'a'] };
+    const { result, rerender } = renderHook(
+      (props) =>
+        useTableState({
+          ...props,
+          storageKey: 'test',
+          setCustomize: jest.fn(),
+        }),
+      {
+        initialProps: { originalHeaders: ['a', 'b'] },
+      }
+    );
+
+    act(() => {
+      result.current.applySettings(saved);
+    });
+    expect(result.current.columnOrder).toEqual(['b', 'a']);
+
+    rerender({ originalHeaders: ['a', 'b', 'c'] });
+
+    act(() => {
+      result.current.applySettings(saved);
+    });
+    expect(result.current.columnOrder).toEqual(['b', 'a', 'c']);
+  });
+});
+


### PR DESCRIPTION
## Summary
- ensure applySettings appends missing headers so new CSV columns stay visible
- add test for columnOrder persistence when CSV schema changes

## Testing
- `npm run build`
- `npm run lint`
- `npm test`
- `npm pack --dry-run`
- `cd demo && npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689edfc3db7c8323bf8b74b23d74e652