### PR TITLE
build: run TypeScript before bundling

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,30 +43,34 @@
     "access": "public"
   },
   "peerDependencies": {
-    "react": ">=18",
-    "react-dom": ">=18",
+    "lucide-react": ">=0.400.0",
     "papaparse": ">=5",
-    "lucide-react": ">=0.400.0"
+    "react": ">=18",
+    "react-dom": ">=18"
   },
   "devDependencies": {
     "@babel/cli": "^7.26.0",
     "@babel/core": "^7.26.0",
     "@babel/preset-env": "^7.26.0",
     "@babel/preset-react": "^7.25.9",
+    "@testing-library/jest-dom": "^6.4.2",
+    "@testing-library/react": "^14.0.0",
+    "@testing-library/user-event": "^14.5.2",
+    "@types/papaparse": "^5.3.7",
+    "@types/react": "18.3.23",
+    "@types/react-dom": "18.3.7",
+    "babel-jest": "^29.7.0",
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-react": "^7.35.0",
-    "rimraf": "^5.0.0",
-    "@testing-library/react": "^14.0.0",
-    "@testing-library/jest-dom": "^6.4.2",
-    "@testing-library/user-event": "^14.5.2",
-    "jest-environment-jsdom": "^29.7.0",
+    "identity-obj-proxy": "^3.0.0",
     "jest": "^29.7.0",
-    "babel-jest": "^29.7.0",
-    "identity-obj-proxy": "^3.0.0"
+    "jest-environment-jsdom": "^29.7.0",
+    "rimraf": "^5.0.0",
+    "typescript": "^5.4.5"
   },
   "scripts": {
-    "build": "rimraf dist && babel src --extensions .js,.jsx,.ts,.tsx --out-dir dist --copy-files",
+    "build": "tsc && rimraf dist && babel src --extensions .js,.jsx,.ts,.tsx --out-dir dist --copy-files",
     "prepare": "npm run build",
     "lint": "eslint src --ext .js,.jsx,.ts,.tsx",
     "test": "jest"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "jsx": "react-jsx",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "allowJs": true,
+    "noEmit": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- add a TypeScript config enabling React JSX and esModuleInterop
- run `tsc` before bundling and declare type definitions

## Testing
- `npm run build`
- `npm run lint`
- `npm test`
- `npm pack --dry-run`
- `cd demo && npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689edb3c041c8323adaefeba0db63e2e