### PR TITLE
refactor: extract csv helpers

### DIFF
--- a/src/hooks/useCsvData.js
+++ b/src/hooks/useCsvData.js
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import Papa from 'papaparse';
+import { parseCSV, normalizeParsed } from '../utils/csv';
 
 /**
  * Load CSV data from a string, URL, or pre-parsed object.
@@ -7,41 +7,6 @@ import Papa from 'papaparse';
  * `status` and `message` fields.
  */
 const useCsvData = ({ csvString, csvURL, csvData }) => {
-  const parseCSV = (csv) => {
-    const result = Papa.parse(csv, {
-      header: true,
-      skipEmptyLines: true,
-      dynamicTyping: true,
-      transformHeader: (h) => (h || '').trim(),
-      transform: (v) => (typeof v === 'string' ? v.trim() : v),
-    });
-
-    const headers = result.meta?.fields || [];
-    const data = (result.data || []).map((row, idx) => {
-      const obj = {};
-      headers.forEach((h) => {
-        obj[h] = row[h] !== undefined && row[h] !== null ? row[h] : '';
-      });
-      obj._id = idx + 1;
-      return obj;
-    });
-    return { headers, data };
-  };
-
-  const normalizeParsed = (parsed) => {
-    const headers = parsed?.meta?.fields || parsed?.headers || [];
-    const rows = parsed?.data || [];
-    const data = rows.map((row, idx) => {
-      const obj = {};
-      headers.forEach((h) => {
-        obj[h] = row[h] !== undefined && row[h] !== null ? row[h] : '';
-      });
-      obj._id = idx + 1;
-      return obj;
-    });
-    return { headers, data };
-  };
-
   const [originalHeaders, setOriginalHeaders] = useState([]);
   const [data, setData] = useState([]);
   const [error, setError] = useState(null);

--- a/src/utils/__tests__/csv.test.js
+++ b/src/utils/__tests__/csv.test.js
@@ -1,0 +1,38 @@
+/* eslint-env jest */
+import { parseCSV, normalizeParsed } from '../csv';
+
+describe('csv utils', () => {
+  test('parseCSV trims headers and applies dynamic typing', () => {
+    const csv = ' name , age \n Alice , 30 \n Bob , 25 \n';
+    const { headers, data } = parseCSV(csv);
+    expect(headers).toEqual(['name', 'age']);
+    expect(data).toEqual([
+      { name: 'Alice', age: 30, _id: 1 },
+      { name: 'Bob', age: 25, _id: 2 },
+    ]);
+    expect(typeof data[0].age).toBe('number');
+  });
+
+  test('parseCSV replaces missing values with empty strings', () => {
+    const csv = 'name,age\nAlice,30\nBob,\n';
+    const { data } = parseCSV(csv);
+    expect(data[1].age).toBe('');
+  });
+
+  test('normalizeParsed replaces null/undefined with empty strings and sequences _id', () => {
+    const parsed = {
+      headers: ['name', 'age'],
+      data: [
+        { name: 'Alice', age: 30 },
+        { name: 'Bob', age: null },
+        { name: 'Eve' },
+      ],
+    };
+    const { data } = normalizeParsed(parsed);
+    expect(data).toEqual([
+      { name: 'Alice', age: 30, _id: 1 },
+      { name: 'Bob', age: '', _id: 2 },
+      { name: 'Eve', age: '', _id: 3 },
+    ]);
+  });
+});

--- a/src/utils/csv.js
+++ b/src/utils/csv.js
@@ -1,0 +1,38 @@
+import Papa from 'papaparse';
+
+export const parseCSV = (csv) => {
+  const result = Papa.parse(csv, {
+    header: true,
+    skipEmptyLines: true,
+    dynamicTyping: true,
+    transformHeader: (h) => (h || '').trim(),
+    transform: (v) => (typeof v === 'string' ? v.trim() : v),
+  });
+
+  const headers = result.meta?.fields || [];
+  const data = (result.data || []).map((row, idx) => {
+    const obj = {};
+    headers.forEach((h) => {
+      obj[h] = row[h] !== undefined && row[h] !== null ? row[h] : '';
+    });
+    obj._id = idx + 1;
+    return obj;
+  });
+  return { headers, data };
+};
+
+export const normalizeParsed = (parsed) => {
+  const headers = parsed?.meta?.fields || parsed?.headers || [];
+  const rows = parsed?.data || [];
+  const data = rows.map((row, idx) => {
+    const obj = {};
+    headers.forEach((h) => {
+      obj[h] = row[h] !== undefined && row[h] !== null ? row[h] : '';
+    });
+    obj._id = idx + 1;
+    return obj;
+  });
+  return { headers, data };
+};
+
+export default { parseCSV, normalizeParsed };


### PR DESCRIPTION
## Summary
- extract `parseCSV` and `normalizeParsed` helpers into `src/utils/csv.js`
- use new csv helpers in `useCsvData`
- add tests covering header trimming, dynamic typing, null replacement, and `_id` sequencing

## Testing
- `npm run build`
- `npm run lint`
- `npm test`
- `npm pack --dry-run`
- `cd demo && npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f050accdc83238ce56912cc21f40f