### PR TITLE
refactor: extract theme utilities and add tests

### DIFF
--- a/src/hooks/__tests__/themeUtils.test.js
+++ b/src/hooks/__tests__/themeUtils.test.js
@@ -1,0 +1,17 @@
+/* eslint-env jest */
+import { THEMES, cycleTheme } from '../themeUtils';
+
+describe('cycleTheme', () => {
+  it('returns next theme for each theme', () => {
+    THEMES.forEach((theme, idx) => {
+      const expected = THEMES[(idx + 1) % THEMES.length];
+      expect(cycleTheme(theme)).toBe(expected);
+    });
+  });
+
+  it('wraps around from last theme to first', () => {
+    const last = THEMES[THEMES.length - 1];
+    expect(cycleTheme(last)).toBe(THEMES[0]);
+  });
+});
+

--- a/src/hooks/themeUtils.js
+++ b/src/hooks/themeUtils.js
@@ -1,0 +1,7 @@
+export const THEMES = ['lite', 'dark', 'solarized', 'dracula', 'monokai', 'gruvbox'];
+
+export const cycleTheme = (currentTheme) => {
+  const idx = THEMES.indexOf(currentTheme);
+  return THEMES[(idx + 1) % THEMES.length];
+};
+

--- a/src/hooks/useTableState.js
+++ b/src/hooks/useTableState.js
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef, useMemo, useCallback } from 'react';
+import { cycleTheme as getNextTheme } from './themeUtils';
 
 const SETTINGS_VERSION = '0.1';
-const THEMES = ['lite', 'dark', 'solarized', 'dracula', 'monokai', 'gruvbox'];
 
 const useTableState = ({
   originalHeaders = [],
@@ -12,9 +12,7 @@ const useTableState = ({
 }) => {
   const [currentTheme, setCurrentTheme] = useState('lite');
   const cycleTheme = () => {
-    const idx = THEMES.indexOf(currentTheme);
-    const next = THEMES[(idx + 1) % THEMES.length];
-    setCurrentTheme(next);
+    setCurrentTheme(getNextTheme(currentTheme));
   };
 
   const [filters, setFilters] = useState({});


### PR DESCRIPTION
## Summary
- move theme cycling logic to new `themeUtils` helper
- update table state hook to consume extracted utility
- add unit tests covering theme cycling and wrap-around

## Testing
- `npm run build`
- `npm run lint`
- `npm test`
- `npm pack --dry-run`
- `cd demo && npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f073ce43c8323a71a1408e122b6c6