### PR TITLE
fix: prevent settings panel from hiding table

### DIFF
--- a/src/ReactTableCsv.jsx
+++ b/src/ReactTableCsv.jsx
@@ -124,6 +124,7 @@ const ReactTableCSV = ({
 
           <SettingsPanel
             {...table}
+            visibleHeaders={table.tableState.visibleHeaders}
             originalHeaders={originalHeaders}
             storageKey={storageKey}
           />

--- a/src/__tests__/SettingsPanel.test.jsx
+++ b/src/__tests__/SettingsPanel.test.jsx
@@ -1,0 +1,36 @@
+/* eslint-env jest */
+import '@testing-library/jest-dom';
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import SettingsPanel from '../components/SettingsPanel';
+
+const noop = () => {};
+
+describe('SettingsPanel', () => {
+  it('shows column position when a column is selected', () => {
+    render(
+      <SettingsPanel
+        showStylePanel
+        selectedColumn="id"
+        columnStyles={{}}
+        setSelectedColumn={noop}
+        updateColumnStyle={noop}
+        hiddenColumns={new Set()}
+        toggleColumnVisibility={noop}
+        setPinnedAnchor={noop}
+        visibleHeaders={['id', 'name']}
+        pinnedIndex={-1}
+        cycleTheme={noop}
+        currentTheme="lite"
+        originalHeaders={['id', 'name']}
+        showRowNumbers={false}
+        setShowRowNumbers={noop}
+        buildSettings={() => ({})}
+        applySettings={noop}
+        storageKey="test"
+      />
+    );
+
+    expect(screen.getByText('Position: #1 of 2')).toBeInTheDocument();
+  });
+});

--- a/src/components/SettingsPanel.jsx
+++ b/src/components/SettingsPanel.jsx
@@ -11,7 +11,7 @@ const SettingsPanel = ({
   hiddenColumns,
   toggleColumnVisibility,
   setPinnedAnchor,
-  visibleHeaders,
+  visibleHeaders = [],
   pinnedIndex,
   cycleTheme,
   currentTheme,


### PR DESCRIPTION
## Summary
- pass visible headers to settings panel to avoid runtime crash
- default missing visible headers to an empty list
- add regression test for selecting columns in the settings panel

## Testing
- `npm run build`
- `npm run lint`
- `npm test`
- `npm pack --dry-run`
- `cd demo && npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689ff4ebd8e48323b20a69a39ed5f71d