### PR TITLE
refactor: extract buildSettings util and add tests

### DIFF
--- a/src/hooks/__tests__/__snapshots__/settingsUtils.test.js.snap
+++ b/src/hooks/__tests__/__snapshots__/settingsUtils.test.js.snap
@@ -1,0 +1,36 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`buildSettings builds settings from state 1`] = `
+{
+  "columnOrder": [
+    "col1",
+    "col2",
+  ],
+  "columnStyles": {
+    "col1": {
+      "width": 100,
+    },
+  },
+  "customize": true,
+  "dropdownFilters": {
+    "col2": [
+      "a",
+      "b",
+    ],
+  },
+  "filterMode": {
+    "col1": "contains",
+  },
+  "filters": {
+    "col1": "foo",
+  },
+  "hiddenColumns": [
+    "col2",
+  ],
+  "pinnedAnchor": "col1",
+  "showFilterRow": true,
+  "showRowNumbers": true,
+  "theme": "dark",
+  "version": "0.1",
+}
+`;

--- a/src/hooks/__tests__/settingsUtils.test.js
+++ b/src/hooks/__tests__/settingsUtils.test.js
@@ -1,0 +1,41 @@
+/* eslint-env jest */
+import { buildSettings } from '../settingsUtils';
+
+describe('buildSettings', () => {
+  it('builds settings from state', () => {
+    const state = {
+      currentTheme: 'dark',
+      columnStyles: { col1: { width: 100 } },
+      columnOrder: ['col1', 'col2'],
+      hiddenColumns: new Set(['col2']),
+      filters: { col1: 'foo' },
+      dropdownFilters: { col2: new Set(['a', 'b']) },
+      filterMode: { col1: 'contains' },
+      showFilterRow: true,
+      pinnedAnchor: 'col1',
+      showRowNumbers: true,
+      customize: true,
+    };
+    expect(buildSettings(state)).toMatchSnapshot();
+  });
+
+  it('converts dropdown filters to arrays', () => {
+    const state = {
+      currentTheme: 'lite',
+      columnStyles: {},
+      columnOrder: [],
+      hiddenColumns: new Set(),
+      filters: {},
+      dropdownFilters: { col1: new Set(['x']) },
+      filterMode: {},
+      showFilterRow: false,
+      pinnedAnchor: null,
+      showRowNumbers: false,
+      customize: false,
+    };
+    const result = buildSettings(state);
+    expect(Array.isArray(result.dropdownFilters.col1)).toBe(true);
+    expect(result.dropdownFilters.col1).toEqual(['x']);
+  });
+});
+

--- a/src/hooks/settingsUtils.js
+++ b/src/hooks/settingsUtils.js
@@ -1,0 +1,37 @@
+export const SETTINGS_VERSION = '0.1';
+
+export const buildSettings = ({
+  currentTheme,
+  columnStyles,
+  columnOrder,
+  hiddenColumns,
+  filters,
+  dropdownFilters,
+  filterMode,
+  showFilterRow,
+  pinnedAnchor,
+  showRowNumbers,
+  customize,
+}) => {
+  const dropdown = {};
+  if (dropdownFilters && typeof dropdownFilters === 'object') {
+    Object.entries(dropdownFilters).forEach(([k, v]) => {
+      dropdown[k] = Array.from(v || []);
+    });
+  }
+  return {
+    version: SETTINGS_VERSION,
+    theme: currentTheme,
+    columnStyles,
+    columnOrder,
+    hiddenColumns: Array.from(hiddenColumns || []),
+    filters,
+    dropdownFilters: dropdown,
+    filterMode,
+    showFilterRow,
+    pinnedAnchor,
+    showRowNumbers,
+    customize,
+  };
+};
+

--- a/src/hooks/useTableState.js
+++ b/src/hooks/useTableState.js
@@ -1,7 +1,6 @@
 import { useState, useEffect, useRef, useMemo, useCallback } from 'react';
 import { cycleTheme as getNextTheme } from './themeUtils';
-
-const SETTINGS_VERSION = '0.1';
+import { buildSettings as createSettings, SETTINGS_VERSION } from './settingsUtils';
 
 const useTableState = ({
   originalHeaders = [],
@@ -104,38 +103,35 @@ const useTableState = ({
   };
 
   const settingsRestoredRef = useRef(false);
-  const buildSettings = useCallback(() => {
-    const dropdown = {};
-    Object.entries(dropdownFilters).forEach(([k, v]) => {
-      dropdown[k] = Array.from(v || []);
-    });
-    return {
-      version: SETTINGS_VERSION,
-      theme: currentTheme,
+  const buildSettings = useCallback(
+    () =>
+      createSettings({
+        currentTheme,
+        columnStyles,
+        columnOrder,
+        hiddenColumns,
+        filters,
+        dropdownFilters,
+        filterMode,
+        showFilterRow,
+        pinnedAnchor,
+        showRowNumbers,
+        customize,
+      }),
+    [
+      currentTheme,
       columnStyles,
       columnOrder,
-      hiddenColumns: Array.from(hiddenColumns),
+      hiddenColumns,
       filters,
-      dropdownFilters: dropdown,
+      dropdownFilters,
       filterMode,
       showFilterRow,
       pinnedAnchor,
       showRowNumbers,
       customize,
-    };
-  }, [
-    columnStyles,
-    columnOrder,
-    hiddenColumns,
-    filters,
-    dropdownFilters,
-    filterMode,
-    showFilterRow,
-    pinnedAnchor,
-    showRowNumbers,
-    customize,
-    currentTheme,
-  ]);
+    ]
+  );
 
   const applySettings = useCallback(
     (s) => {


### PR DESCRIPTION
## Summary
- move buildSettings logic into standalone settingsUtils with SETTINGS_VERSION constant
- refactor useTableState to delegate settings creation to new util
- add unit tests for buildSettings ensuring dropdown filters serialize as arrays

## Testing
- `npm run build`
- `npm run lint`
- `npm test`
- `npm pack --dry-run`
- `cd demo && npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a0143d1fe883239630e99c99ba73af