### PR TITLE
refactor: internalize header in ReactTableCSV

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ Notes
 - `downloadFilename?: string` Filename for exports. Default `"data.csv"`.
 - `storageKey?: string` localStorage key for settings. Default `"react-table-csv-key"`.
 - `defaultSettings?: string` JSON string (same schema as exported) used as defaults and fallback if localStorage is missing/corrupt.
+- `title?: string` Optional title displayed in a themed header above the table.
+- `collapsed?: boolean` Render the table initially collapsed with a toggle in the header.
 - Theme selection is managed inside the component's settings. Use the Settings panel to cycle themes; the current theme is saved to `localStorage` and included when exporting settings.
 
 ### ReactDashboardCSV Props

--- a/index.d.ts
+++ b/index.d.ts
@@ -7,7 +7,8 @@ export interface ReactTableCSVProps {
   downloadFilename?: string;
   storageKey?: string;
   defaultSettings?: string | null;
-  onThemeChange?: (theme: string) => void;
+  title?: string;
+  collapsed?: boolean;
 }
 
 export const ReactTableCSV: React.FC<ReactTableCSVProps>;

--- a/src/__tests__/ReactDashboardCsv.test.jsx
+++ b/src/__tests__/ReactDashboardCsv.test.jsx
@@ -79,7 +79,7 @@ describe('ReactDashboardCSV', () => {
     }, { timeout: 2000 });
   });
 
-  it('preserves theme and settings across collapse/expand and syncs header theme', async () => {
+  it('preserves theme across collapse/expand', async () => {
     render(
       <ReactDashboardCSV
         datasets={{ sample: { csvString: 'a,b\n1,2' } }}

--- a/src/__tests__/ReactTableCsv.test.jsx
+++ b/src/__tests__/ReactTableCsv.test.jsx
@@ -71,4 +71,23 @@ describe('ReactTableCSV', () => {
     expect(screen.getByText('Settings')).toBeInTheDocument();
     expect(screen.queryByText('Hide Settings')).not.toBeInTheDocument();
   });
+
+  it('respects the collapsed prop and toggles', () => {
+    const csvData = {
+      headers: ['id', 'name'],
+      data: [
+        { id: 1, name: 'Alice' },
+      ],
+    };
+
+    render(<ReactTableCSV csvData={csvData} title="Sample" collapsed />);
+
+    // Table content rendered but hidden initially
+    const info = screen.getByText('Showing 1 of 1 rows | 2 of 2 columns');
+    expect(info).not.toBeVisible();
+
+    // Expand and expect content to be visible
+    fireEvent.click(screen.getByText('Expand'));
+    expect(info).toBeVisible();
+  });
 });


### PR DESCRIPTION
## Summary
- move title/collapse header into ReactTableCSV and add `collapsed` prop
- simplify ReactDashboardCsv now that header theming is handled internally
- document new props and update tests

## Testing
- `npm run build`
- `npm run lint`
- `npm test`
- `npm pack --dry-run`
- `cd demo && npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ae7cbb267483239bbcba611a78d57a