### PR TITLE
feat: add table height and font size settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ Notes
 - `defaultSettings?: string` JSON string (same schema as exported) used as defaults and fallback if localStorage is missing/corrupt.
 - `title?: string` Optional title displayed in a themed header above the table.
 - `collapsed?: boolean` Render the table initially collapsed with a toggle in the header.
+- `maxHeight?: string` Limit table height (e.g., `'400px'`, `'50vh'`). Use `'unlimited'` for no limit.
+- `fontSize?: number` Font size for table values in pixels. Default `13`.
 - Theme selection is managed inside the component's settings. Use the Settings panel to cycle themes; the current theme is saved to `localStorage` and included when exporting settings.
 
 ### ReactDashboardCSV Props
@@ -112,7 +114,7 @@ Notes
   - Optional `title` shows above the table; optional `collapsed` renders the view initially collapsed with a toggle.
 
 ## Exported/Imported Settings (high‑level)
-- `{ version, theme, columnStyles, columnOrder, hiddenColumns, filters, dropdownFilters, filterMode, showFilterRow, pinnedAnchor, showRowNumbers, customize }`
+- `{ version, theme, columnStyles, columnOrder, hiddenColumns, filters, dropdownFilters, filterMode, showFilterRow, pinnedAnchor, showRowNumbers, customize, tableMaxHeight, fontSize }`
 
 ## Resetting Settings
 Call `resetSettings()` to revert the table to its initial configuration. The reset also turns off customize mode (or respects a `customize` value from provided defaults) and returns the applied settings object.

--- a/index.d.ts
+++ b/index.d.ts
@@ -9,6 +9,8 @@ export interface ReactTableCSVProps {
   defaultSettings?: string | null;
   title?: string;
   collapsed?: boolean;
+  maxHeight?: string;
+  fontSize?: number;
 }
 
 export const ReactTableCSV: React.FC<ReactTableCSVProps>;

--- a/src/ReactTableCsv.jsx
+++ b/src/ReactTableCsv.jsx
@@ -16,6 +16,8 @@ const ReactTableCSV = ({
   defaultSettings = '',
   title,
   collapsed: collapsedProp = false,
+  maxHeight = 'unlimited',
+  fontSize: fontSizeProp = 13,
 }) => {
   const { originalHeaders, data, error } = useCsvData({ csvString, csvURL, csvData });
   const [customize, setCustomize] = useState(false);
@@ -30,6 +32,8 @@ const ReactTableCSV = ({
     defaultSettings,
     customize,
     setCustomize,
+    defaultMaxHeight: maxHeight,
+    defaultFontSize: fontSizeProp,
   });
 
   // When leaving customize mode, auto-hide the Settings panel for a clearer UX
@@ -151,7 +155,10 @@ const ReactTableCSV = ({
 
   if (!title) {
     return (
-      <div className={`${styles.root} ${styles[table.currentTheme] || styles.lite}`}>
+      <div
+        className={`${styles.root} ${styles[table.currentTheme] || styles.lite}`}
+        style={table.tableMaxHeight === 'unlimited' ? { minHeight: '100vh' } : undefined}
+      >
         <div className={styles.container}>
           <div className={styles.card}>{tableBody}</div>
         </div>

--- a/src/ReactTableCsv.module.css
+++ b/src/ReactTableCsv.module.css
@@ -104,7 +104,7 @@
 }
 
 .root {
-  min-height: 100vh;
+  min-height: 0;
   padding: 4px;
   background: var(--bg);
   color: var(--text);

--- a/src/__tests__/SettingsPanel.test.jsx
+++ b/src/__tests__/SettingsPanel.test.jsx
@@ -28,6 +28,10 @@ describe('SettingsPanel', () => {
         buildSettings={() => ({})}
         applySettings={noop}
         storageKey="test"
+        tableMaxHeight="unlimited"
+        setTableMaxHeight={noop}
+        fontSize={13}
+        setFontSize={noop}
       />
     );
 

--- a/src/components/DataTable.jsx
+++ b/src/components/DataTable.jsx
@@ -74,6 +74,8 @@ const DataTable = ({
   toggleColumnVisibility,
   pinnedAnchor,
   setPinnedAnchor,
+  tableMaxHeight,
+  fontSize,
   onDataProcessed,
 }) => {
   const [activeDropdown, setActiveDropdown] = useState(null);
@@ -82,6 +84,9 @@ const DataTable = ({
   const [pinnedOffsets, setPinnedOffsets] = useState({});
   const headerRefs = useRef({});
   const rowNumHeaderRef = useRef(null);
+  const wrapStyle = tableMaxHeight && tableMaxHeight !== 'unlimited'
+    ? { maxHeight: tableMaxHeight, overflowY: 'auto' }
+    : {};
 
   const visibleHeaders = useMemo(() => {
     return columnOrder.filter(header => !hiddenColumns.has(header));
@@ -588,7 +593,7 @@ const DataTable = ({
   return (
     <>
       {(!splitGroups || splitGroups.length === 0) ? (
-        <div className={styles.tableWrap}>
+        <div className={styles.tableWrap} style={wrapStyle}>
           <table className={styles.table} style={{ tableLayout: 'auto' }}>
             <thead>
               <tr className={styles.theadRow}>
@@ -815,7 +820,10 @@ const DataTable = ({
                   className={styles.row}
                 >
                   {showRowNumbers && (
-                    <td className={`${styles.cell} ${styles.stickyCell} ${styles.rowNoCell}`} style={{ left: 0, textAlign: 'right' }}>
+                    <td
+                      className={`${styles.cell} ${styles.stickyCell} ${styles.rowNoCell}`}
+                      style={{ left: 0, textAlign: 'right', fontSize: `${fontSize}px` }}
+                    >
                       {index + 1}
                     </td>
                   )}
@@ -823,10 +831,14 @@ const DataTable = ({
                     <td
                       key={`${index}-${header}`}
                       className={`${styles.cell} ${isPinnedHeader(header) ? styles.stickyCell : ''} ${isPinnedLast(header) ? styles.pinnedDivider : ''}`}
-                      style={isPinnedHeader(header) ? { ...getColumnStyle(header), left: `${pinnedOffsets[header] || 0}px` } : getColumnStyle(header)}
+                      style={isPinnedHeader(header)
+                        ? { ...getColumnStyle(header), fontSize: `${fontSize}px`, left: `${pinnedOffsets[header] || 0}px` }
+                        : { ...getColumnStyle(header), fontSize: `${fontSize}px` }}
                       title={columnStyles[header]?.noWrap ? row[header] : undefined}
                     >
-                      {formatNumberForDisplay(header, row[header])}
+                      <div className={styles.valueText} style={{ fontSize: `${fontSize}px` }}>
+                        {formatNumberForDisplay(header, row[header])}
+                      </div>
                     </td>
                   ))}
                 </tr>
@@ -849,7 +861,7 @@ const DataTable = ({
               <h2 className={styles.splitTitle}>
                 {splitByColumns.map((h, idx) => `${h}: ${g.keyVals[idx]}`).join(' • ')}
               </h2>
-              <div className={styles.tableWrap}>
+              <div className={styles.tableWrap} style={wrapStyle}>
                 <table className={styles.table} style={{ tableLayout: 'auto' }}>
                   <thead>
                     <tr className={styles.theadRow}>
@@ -1061,7 +1073,10 @@ const DataTable = ({
                     })().map((row, index) => (
                       <tr key={row._id || row._gid || index} className={styles.row}>
                         {showRowNumbers && (
-                          <td className={`${styles.cell} ${styles.stickyCell} ${styles.rowNoCell}`} style={{ left: 0, textAlign: 'right' }}>
+                          <td
+                            className={`${styles.cell} ${styles.stickyCell} ${styles.rowNoCell}`}
+                            style={{ left: 0, textAlign: 'right', fontSize: `${fontSize}px` }}
+                          >
                             {index + 1}
                           </td>
                         )}
@@ -1069,10 +1084,14 @@ const DataTable = ({
                           <td
                             key={`${index}-${header}`}
                             className={`${styles.cell} ${isPinnedHeader(header) ? styles.stickyCell : ''} ${isPinnedLast(header) ? styles.pinnedDivider : ''}`}
-                            style={isPinnedHeader(header) ? { ...getColumnStyle(header), left: `${pinnedOffsets[header] || 0}px` } : getColumnStyle(header)}
+                            style={isPinnedHeader(header)
+                              ? { ...getColumnStyle(header), fontSize: `${fontSize}px`, left: `${pinnedOffsets[header] || 0}px` }
+                              : { ...getColumnStyle(header), fontSize: `${fontSize}px` }}
                             title={columnStyles[header]?.noWrap ? row[header] : undefined}
                           >
-                            {formatNumberForDisplay(header, row[header])}
+                            <div className={styles.valueText} style={{ fontSize: `${fontSize}px` }}>
+                              {formatNumberForDisplay(header, row[header])}
+                            </div>
                           </td>
                         ))}
                       </tr>

--- a/src/components/SettingsPanel.jsx
+++ b/src/components/SettingsPanel.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Hash, SunMoon, Type, Paintbrush, AlignLeft, AlignCenter, AlignRight, Columns, List, WrapText, Eye, EyeOff, Pin, PinOff, Scissors, X } from 'lucide-react';
+import { Hash, SunMoon, Type, Paintbrush, AlignLeft, AlignCenter, AlignRight, Columns, List, WrapText, Eye, EyeOff, Pin, PinOff, Scissors, X, Maximize } from 'lucide-react';
 import styles from '../ReactTableCsv.module.css';
 
 const SettingsPanel = ({
@@ -21,6 +21,10 @@ const SettingsPanel = ({
   buildSettings,
   applySettings,
   storageKey,
+  tableMaxHeight,
+  setTableMaxHeight,
+  fontSize,
+  setFontSize,
 }) => {
   const handleExportSettings = () => {
     try {
@@ -60,6 +64,54 @@ const SettingsPanel = ({
           <Hash size={16} />
           <span>Show row numbers</span>
         </label>
+        <div className={styles.widthGroup}>
+          <Maximize size={16} />
+          <span className={styles.muted}>Max height:</span>
+          <input
+            type="number"
+            placeholder="unlimited"
+            value={tableMaxHeight === 'unlimited' ? '' : parseInt(tableMaxHeight, 10) || ''}
+            onChange={(e) => {
+              const v = e.target.value;
+              const unit = tableMaxHeight === 'unlimited' ? 'px' : tableMaxHeight.endsWith('vh') ? 'vh' : 'px';
+              if (!v) setTableMaxHeight('unlimited');
+              else setTableMaxHeight(`${v}${unit}`);
+            }}
+            className={styles.widthInput}
+            disabled={tableMaxHeight === 'unlimited'}
+          />
+          <select
+            value={tableMaxHeight === 'unlimited' ? 'unlimited' : tableMaxHeight.endsWith('vh') ? 'vh' : 'px'}
+            onChange={(e) => {
+              const unit = e.target.value;
+              if (unit === 'unlimited') {
+                setTableMaxHeight('unlimited');
+              } else {
+                const num = tableMaxHeight === 'unlimited' ? 0 : parseInt(tableMaxHeight, 10) || 0;
+                setTableMaxHeight(`${num}${unit}`);
+              }
+            }}
+            className={styles.unitSelect}
+          >
+            <option value="unlimited">unlimited</option>
+            <option value="px">px</option>
+            <option value="vh">vh</option>
+          </select>
+        </div>
+        <div className={styles.widthGroup}>
+          <Type size={16} />
+          <span className={styles.muted}>Font:</span>
+          <input
+            type="number"
+            value={fontSize}
+            onChange={(e) => {
+              const v = parseInt(e.target.value, 10);
+              if (!Number.isNaN(v)) setFontSize(v);
+            }}
+            className={styles.widthInput}
+          />
+          <span className={styles.muted}>px</span>
+        </div>
         <div className={styles.reducerGroup}>
           <button className={styles.btn} onClick={handleExportSettings} title="Copy settings JSON to clipboard">Export settings</button>
           <button className={styles.btn} onClick={handleImportSettings} title="Paste settings JSON to import">Import settings</button>

--- a/src/hooks/__tests__/__snapshots__/settingsUtils.test.js.snap
+++ b/src/hooks/__tests__/__snapshots__/settingsUtils.test.js.snap
@@ -24,12 +24,14 @@ exports[`buildSettings builds settings from state 1`] = `
   "filters": {
     "col1": "foo",
   },
+  "fontSize": 14,
   "hiddenColumns": [
     "col2",
   ],
   "pinnedAnchor": "col1",
   "showFilterRow": true,
   "showRowNumbers": true,
+  "tableMaxHeight": "500px",
   "theme": "dark",
   "version": "0.1",
 }

--- a/src/hooks/__tests__/settingsUtils.test.js
+++ b/src/hooks/__tests__/settingsUtils.test.js
@@ -15,6 +15,8 @@ describe('buildSettings', () => {
       pinnedAnchor: 'col1',
       showRowNumbers: true,
       customize: true,
+      tableMaxHeight: '500px',
+      fontSize: 14,
     };
     expect(buildSettings(state)).toMatchSnapshot();
   });
@@ -32,6 +34,8 @@ describe('buildSettings', () => {
       pinnedAnchor: null,
       showRowNumbers: false,
       customize: false,
+      tableMaxHeight: 'unlimited',
+      fontSize: 13,
     };
     const result = buildSettings(state);
     expect(Array.isArray(result.dropdownFilters.col1)).toBe(true);

--- a/src/hooks/settingsUtils.js
+++ b/src/hooks/settingsUtils.js
@@ -12,6 +12,8 @@ export const buildSettings = ({
   pinnedAnchor,
   showRowNumbers,
   customize,
+  tableMaxHeight,
+  fontSize,
 }) => {
   const dropdown = {};
   if (dropdownFilters && typeof dropdownFilters === 'object') {
@@ -32,6 +34,8 @@ export const buildSettings = ({
     pinnedAnchor,
     showRowNumbers,
     customize,
+    tableMaxHeight,
+    fontSize,
   };
 };
 

--- a/src/hooks/useTableState.js
+++ b/src/hooks/useTableState.js
@@ -8,6 +8,8 @@ const useTableState = ({
   defaultSettings,
   customize,
   setCustomize,
+  defaultMaxHeight = 'unlimited',
+  defaultFontSize = 13,
 }) => {
   const [currentTheme, setCurrentTheme] = useState('lite');
   const cycleTheme = () => {
@@ -25,6 +27,8 @@ const useTableState = ({
   const [hiddenColumns, setHiddenColumns] = useState(new Set());
   const [pinnedAnchor, setPinnedAnchor] = useState(null);
   const [showRowNumbers, setShowRowNumbers] = useState(false);
+  const [tableMaxHeight, setTableMaxHeight] = useState(defaultMaxHeight);
+  const [fontSize, setFontSize] = useState(defaultFontSize);
   const [tableState, setTableState] = useState({ visibleHeaders: [], rows: [] });
 
   const defaultSettingsObj = useMemo(() => {
@@ -116,8 +120,10 @@ const useTableState = ({
         showFilterRow,
         pinnedAnchor,
         showRowNumbers,
-        customize,
-      }),
+      customize,
+      tableMaxHeight,
+      fontSize,
+    }),
     [
       currentTheme,
       columnStyles,
@@ -130,6 +136,8 @@ const useTableState = ({
       pinnedAnchor,
       showRowNumbers,
       customize,
+      tableMaxHeight,
+      fontSize,
     ]
   );
 
@@ -162,6 +170,8 @@ const useTableState = ({
         if (typeof s.showRowNumbers === 'boolean') setShowRowNumbers(s.showRowNumbers);
         if (typeof s.customize === 'boolean') setCustomize(s.customize);
         if (typeof s.theme === 'string') setCurrentTheme(s.theme);
+        if (typeof s.tableMaxHeight === 'string') setTableMaxHeight(s.tableMaxHeight);
+        if (typeof s.fontSize === 'number') setFontSize(s.fontSize);
         if (typeof s.editable === 'boolean' && typeof s.customize !== 'boolean')
           setCustomize(s.editable);
       } catch {
@@ -217,7 +227,7 @@ const useTableState = ({
 
   const resetSettings = () => {
     const initial = defaultSettingsObj
-      ? { ...defaultSettingsObj }
+      ? { tableMaxHeight: defaultMaxHeight, fontSize: defaultFontSize, ...defaultSettingsObj }
       : {
           columnStyles: {},
           columnOrder: originalHeaders,
@@ -230,6 +240,8 @@ const useTableState = ({
           showRowNumbers: false,
           theme: 'lite',
           customize: false,
+          tableMaxHeight: defaultMaxHeight,
+          fontSize: defaultFontSize,
         };
 
     if (typeof initial.customize !== 'boolean') initial.customize = false;
@@ -283,6 +295,10 @@ const useTableState = ({
     buildSettings,
     applySettings,
     resetSettings,
+    tableMaxHeight,
+    setTableMaxHeight,
+    fontSize,
+    setFontSize,
   };
 };
 


### PR DESCRIPTION
## Summary
- add configurable table height with px, vh, or unlimited options
- allow adjusting table value font size
- document new props and persist settings

## Testing
- `npm run build`
- `npm run lint`
- `npm test`
- `npm pack --dry-run`
- `cd demo && npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68afb0d96a608323bb20ba87ad858568