### PR TITLE
fix: pin filter inputs with column headers

### DIFF
--- a/src/ReactTableCsv.module.css
+++ b/src/ReactTableCsv.module.css
@@ -220,8 +220,9 @@
 .rowNoHeadHidden { width: 0 !important; min-width: 0 !important; max-width: 0 !important; padding: 0 !important; border: none !important; }
 
 .filterRow { background: var(--filter-bg); border-bottom: 2px solid #cfe3ff; }
-.filterCell { position: relative; padding: 6px 10px; }
+.filterCell { position: sticky; padding: 6px 10px; background: var(--filter-bg); z-index: 3; }
 .filterCellInner { display: flex; align-items: center; gap: 6px; }
+.stickyFilter { left: 0; z-index: 4; }
 .iconBtn { padding: 6px; border-radius: 8px; border: 1px solid var(--border); background: var(--surface); color: var(--text); cursor: pointer; }
 .iconBtnActive { background: var(--primary); color: #fff; border-color: transparent; }
 .flex1Relative { position: relative; flex: 1; display: flex; align-items: center; gap: 6px; min-width: 0; }

--- a/src/components/DataTable.jsx
+++ b/src/components/DataTable.jsx
@@ -82,6 +82,7 @@ const DataTable = ({
   const [draggedColumn, setDraggedColumn] = useState(null);
   const [dragOverColumn, setDragOverColumn] = useState(null);
   const [pinnedOffsets, setPinnedOffsets] = useState({});
+  const [headerHeight, setHeaderHeight] = useState(0);
   const headerRefs = useRef({});
   const rowNumHeaderRef = useRef(null);
   const wrapStyle = tableMaxHeight && tableMaxHeight !== 'unlimited'
@@ -549,6 +550,10 @@ const DataTable = ({
   }, [displayedRows, splitByColumns]);
 
   useLayoutEffect(() => {
+    const ref = showRowNumbers ? rowNumHeaderRef.current : headerRefs.current[visibleHeaders[0]];
+    if (ref) {
+      setHeaderHeight(ref.getBoundingClientRect().height);
+    }
     if (pinnedIndex < 0) {
       setPinnedOffsets({});
       return;
@@ -563,7 +568,7 @@ const DataTable = ({
       left += width;
     }
     setPinnedOffsets(offsets);
-  }, [visibleHeaders, columnStyles, pinnedIndex, data, showFilterRow, showRowNumbers]);
+  }, [visibleHeaders, columnStyles, pinnedIndex, data, showFilterRow, showRowNumbers, isCustomize, selectedColumn]);
 
   useEffect(() => {
     const onResize = () => {
@@ -579,10 +584,14 @@ const DataTable = ({
         }
         setPinnedOffsets(offsets);
       }
+      const ref = showRowNumbers ? rowNumHeaderRef.current : headerRefs.current[visibleHeaders[0]];
+      if (ref) {
+        setHeaderHeight(ref.getBoundingClientRect().height);
+      }
     };
     window.addEventListener('resize', onResize);
     return () => window.removeEventListener('resize', onResize);
-  }, [visibleHeaders, pinnedIndex, showRowNumbers]);
+  }, [visibleHeaders, pinnedIndex, showRowNumbers, isCustomize]);
 
   useEffect(() => {
     if (onDataProcessed) {
@@ -724,10 +733,19 @@ const DataTable = ({
               {showFilterRow && (
                 <tr className={styles.filterRow}>
                   {showRowNumbers && (
-                    <th className={styles.filterCell} />
+                    <th
+                      className={`${styles.filterCell} ${styles.stickyFilter} ${styles.rowNoHead}`}
+                      style={{ left: 0, top: `${headerHeight}px` }}
+                    />
                   )}
                   {visibleHeaders.map(header => (
-                    <th key={`filter-${header}`} className={styles.filterCell}>
+                    <th
+                      key={`filter-${header}`}
+                      className={`${styles.filterCell} ${isPinnedHeader(header) ? styles.stickyFilter : ''} ${isPinnedLast(header) ? styles.pinnedDivider : ''}`}
+                      style={isPinnedHeader(header)
+                        ? { left: `${pinnedOffsets[header] || 0}px`, top: `${headerHeight}px` }
+                        : { top: `${headerHeight}px` }}
+                    >
                       <div className={styles.filterCellInner}>
                         <button
                           onClick={() => toggleFilterMode(header)}


### PR DESCRIPTION
## Summary
- keep filter row fixed beneath column headers when scrolling vertically
- keep filter inputs aligned with pinned columns during horizontal scroll

## Testing
- `npm run build`
- `npm run lint`
- `npm test`
- `npm pack --dry-run`
- `cd demo && npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68afcbf8ab148323ba280861c6b950c6