### PR TITLE
feat: move filter toggle to header with icon buttons

### DIFF
--- a/src/ReactTableCsv.jsx
+++ b/src/ReactTableCsv.jsx
@@ -6,6 +6,7 @@ import Toolbar from './components/Toolbar';
 import SettingsPanel from './components/SettingsPanel';
 import DataTable from './components/DataTable';
 import styles from './ReactTableCsv.module.css';
+import { Filter, Settings as SettingsIcon, Plus, Minus } from 'lucide-react';
 
 const ReactTableCSV = ({
   csvString,
@@ -124,15 +125,21 @@ const ReactTableCSV = ({
   const tableBody = (
     <>
       {!title && (
-        <div style={{ display: 'flex', justifyContent: 'flex-end', marginBottom: 8 }}>
-          <label className={styles.checkboxRow} title="Toggle customize mode">
-            <input
-              type="checkbox"
-              checked={customize}
-              onChange={(e) => setCustomize(e.target.checked)}
-            />
-            <span>Customize</span>
-          </label>
+        <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 8, marginBottom: 8 }}>
+          <button
+            onClick={() => table.setShowFilterRow(!table.showFilterRow)}
+            className={`${styles.iconBtn} ${styles.headerBtn} ${table.showFilterRow ? styles.iconBtnActive : ''}`}
+            title={table.showFilterRow ? 'Hide Filters' : 'Show Filters'}
+          >
+            <Filter size={16} />
+          </button>
+          <button
+            onClick={() => setCustomize((c) => !c)}
+            className={`${styles.iconBtn} ${styles.headerBtn} ${customize ? styles.iconBtnActive : ''}`}
+            title="Toggle customize mode"
+          >
+            <SettingsIcon size={16} />
+          </button>
         </div>
       )}
 
@@ -197,27 +204,26 @@ const ReactTableCSV = ({
       >
         <div style={{ fontWeight: 600 }}>{title}</div>
         <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-          <label className={styles.checkboxRow} title="Toggle customize mode">
-            <input
-              type="checkbox"
-              checked={customize}
-              onChange={(e) => setCustomize(e.target.checked)}
-            />
-            <span>Customize</span>
-          </label>
+          <button
+            onClick={() => table.setShowFilterRow(!table.showFilterRow)}
+            className={`${styles.iconBtn} ${styles.headerBtn} ${table.showFilterRow ? styles.iconBtnActive : ''}`}
+            title={table.showFilterRow ? 'Hide Filters' : 'Show Filters'}
+          >
+            <Filter size={16} />
+          </button>
+          <button
+            onClick={() => setCustomize((c) => !c)}
+            className={`${styles.iconBtn} ${styles.headerBtn} ${customize ? styles.iconBtnActive : ''}`}
+            title="Toggle customize mode"
+          >
+            <SettingsIcon size={16} />
+          </button>
           <button
             onClick={() => setCollapsed((c) => !c)}
-            style={{
-              fontSize: 12,
-              padding: '4px 8px',
-              border: '1px solid var(--border)',
-              borderRadius: 4,
-              background: 'var(--surface)',
-              color: 'var(--btn-text)',
-              cursor: 'pointer',
-            }}
+            className={`${styles.iconBtn} ${styles.headerBtn}`}
+            title={collapsed ? 'Expand' : 'Collapse'}
           >
-            {collapsed ? 'Expand' : 'Collapse'}
+            {collapsed ? <Plus size={16} /> : <Minus size={16} />}
           </button>
         </div>
       </div>

--- a/src/ReactTableCsv.module.css
+++ b/src/ReactTableCsv.module.css
@@ -225,6 +225,7 @@
 .stickyFilter { left: 0; z-index: 4; }
 .iconBtn { padding: 6px; border-radius: 8px; border: 1px solid var(--border); background: var(--surface); color: var(--text); cursor: pointer; }
 .iconBtnActive { background: var(--primary); color: #fff; border-color: transparent; }
+.headerBtn { width: 32px; height: 32px; padding: 0; display: inline-flex; align-items: center; justify-content: center; }
 .flex1Relative { position: relative; flex: 1; display: flex; align-items: center; gap: 6px; min-width: 0; }
 .dropdownTrigger { flex: 1; min-width: 0; padding: 6px 8px; border: 1px solid var(--border); border-radius: 8px; background: var(--surface); color: var(--text); text-align: left; font-size: 13px; display: flex; align-items: center; justify-content: space-between; }
 .truncate { display: inline-block; max-width: 85%; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }

--- a/src/__tests__/ReactDashboardCsv.test.jsx
+++ b/src/__tests__/ReactDashboardCsv.test.jsx
@@ -95,15 +95,15 @@ describe('ReactDashboardCSV', () => {
     await screen.findByText('2', {}, { timeout: 2000 });
 
     // Enter customize -> settings -> change theme
-    fireEvent.click(screen.getByLabelText('Customize'));
+    fireEvent.click(screen.getByTitle('Toggle customize mode'));
     fireEvent.click(screen.getByText('Settings'));
     fireEvent.click(screen.getByText(/Theme:/)); // cycles to dark per theme order
 
     // Collapse
-    fireEvent.click(screen.getByText('Collapse'));
+    fireEvent.click(screen.getByTitle('Collapse'));
 
     // Expand
-    fireEvent.click(screen.getByText('Expand'));
+    fireEvent.click(screen.getByTitle('Expand'));
 
     // Still shows row text and the wrapper has class for the new theme
     await screen.findByText(/Showing\s+1\s+of\s+1\s+rows/, {}, { timeout: 2000 });

--- a/src/__tests__/ReactTableCsv.test.jsx
+++ b/src/__tests__/ReactTableCsv.test.jsx
@@ -20,7 +20,7 @@ describe('ReactTableCSV', () => {
       screen.queryByText('Showing 2 of 2 rows | 2 of 2 columns')
     ).not.toBeInTheDocument();
 
-    fireEvent.click(screen.getByText('Customize'));
+    fireEvent.click(screen.getByTitle('Toggle customize mode'));
 
     expect(
       screen.getByText('Showing 2 of 2 rows | 2 of 2 columns')
@@ -39,7 +39,7 @@ describe('ReactTableCSV', () => {
 
     render(<ReactTableCSV csvData={csvData} storageKey={storageKey} />);
 
-    fireEvent.click(screen.getByText('Customize'));
+    fireEvent.click(screen.getByTitle('Toggle customize mode'));
     fireEvent.click(screen.getByText('Settings'));
     fireEvent.click(screen.getByText(/Theme:/));
 
@@ -60,7 +60,7 @@ describe('ReactTableCSV', () => {
 
     render(<ReactTableCSV csvData={csvData} title="Sample" />);
 
-    expect(screen.getByLabelText('Customize')).toBeInTheDocument();
+    expect(screen.getByTitle('Toggle customize mode')).toBeInTheDocument();
   });
 
   it('respects the collapsed prop and toggles', () => {
@@ -78,7 +78,7 @@ describe('ReactTableCSV', () => {
     expect(cell).not.toBeVisible();
 
     // Expand and expect content to be visible
-    fireEvent.click(screen.getByText('Expand'));
+    fireEvent.click(screen.getByTitle('Expand'));
     expect(cell).toBeVisible();
   });
 });

--- a/src/components/Toolbar.jsx
+++ b/src/components/Toolbar.jsx
@@ -1,10 +1,8 @@
 import React from 'react';
-import { Filter, X, Download, Copy, RefreshCw, Settings as SettingsIcon } from 'lucide-react';
+import { X, Download, Copy, RefreshCw, Settings as SettingsIcon } from 'lucide-react';
 import styles from '../ReactTableCsv.module.css';
 
 const Toolbar = ({
-  showFilterRow,
-  setShowFilterRow,
   clearAllFilters,
   showStylePanel,
   setShowStylePanel,
@@ -20,14 +18,6 @@ const Toolbar = ({
   return (
     <div className={styles.controls}>
       <div className={styles.controlsLeft}>
-        <button
-          onClick={() => setShowFilterRow(!showFilterRow)}
-          className={`${styles.btn} ${showFilterRow ? styles.btnPrimaryActive : ''}`}
-        >
-          <Filter size={18} />
-          {showFilterRow ? 'Hide Filters' : 'Show Filters'}
-        </button>
-
         <button onClick={clearAllFilters} className={styles.btn}>
           <X size={18} />
           Reset Filters


### PR DESCRIPTION
## Summary
- move filter toggle to the table header and add customize/collapse icons
- align header control sizes with new `headerBtn` style
- adjust tests for icon-based controls

## Testing
- `npm run build`
- `npm run lint`
- `npm test`
- `npm pack --dry-run`
- `cd demo && npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b093f25e648323ac5b10f41591bb03