### PR TITLE
feat: allow sorting when filters visible

### DIFF
--- a/src/__tests__/ReactTableCsv.test.jsx
+++ b/src/__tests__/ReactTableCsv.test.jsx
@@ -81,4 +81,26 @@ describe('ReactTableCSV', () => {
     fireEvent.click(screen.getByTitle('Expand'));
     expect(cell).toBeVisible();
   });
+
+  it('allows sorting when filters are visible without customize mode', () => {
+    const csvData = {
+      headers: ['id'],
+      data: [
+        { id: 2 },
+        { id: 1 },
+      ],
+    };
+
+    render(<ReactTableCSV csvData={csvData} />);
+
+    fireEvent.click(screen.getByTitle('Show Filters'));
+
+    const rowsBefore = screen.getAllByRole('row');
+    expect(rowsBefore[2]).toHaveTextContent('2');
+
+    fireEvent.click(screen.getByText('id'));
+
+    const rowsAfter = screen.getAllByRole('row');
+    expect(rowsAfter[2]).toHaveTextContent('1');
+  });
 });

--- a/src/components/DataTable.jsx
+++ b/src/components/DataTable.jsx
@@ -633,7 +633,7 @@ const DataTable = ({
                         <div className={styles.thLeft}>
                           {isCustomize && <GripVertical size={14} />}
                           <span
-                            onClick={isCustomize ? () => toggleHeaderSort(header) : undefined}
+                            onClick={(isCustomize || showFilterRow) ? () => toggleHeaderSort(header) : undefined}
                             title={(() => {
                               const hasGroup = groupByColumns.length > 0;
                               const isGrouped = groupByColumns.includes(header);
@@ -649,28 +649,28 @@ const DataTable = ({
                         </div>
                         <div className={styles.headerRight}>
                           {isCustomize && (
-                            <>
-                              <button
-                                className={`${styles.iconBtn} ${selectedColumn === header && showStylePanel ? styles.iconBtnActive : ''}`}
-                                title={selectedColumn === header && showStylePanel ? 'Close settings' : 'Customize this column'}
-                                onClick={(e) => {
-                                  e.stopPropagation();
-                                  if (selectedColumn === header && showStylePanel) {
-                                    setSelectedColumn('');
-                                    setShowStylePanel(false);
-                                  } else {
-                                    setSelectedColumn(header);
-                                    setShowStylePanel(true);
-                                  }
-                                }}
-                              >
-                                <SettingsIcon size={14} />
-                              </button>
-                              <div className={styles.sortIcons}>
-                                <ChevronUp size={12} className={isSortAsc(header) ? styles.sortActive : styles.sortInactive} />
-                                <ChevronDown size={12} className={isSortDesc(header) ? styles.sortActive : styles.sortInactive} style={{ marginTop: '-3px' }} />
-                              </div>
-                            </>
+                            <button
+                              className={`${styles.iconBtn} ${selectedColumn === header && showStylePanel ? styles.iconBtnActive : ''}`}
+                              title={selectedColumn === header && showStylePanel ? 'Close settings' : 'Customize this column'}
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                if (selectedColumn === header && showStylePanel) {
+                                  setSelectedColumn('');
+                                  setShowStylePanel(false);
+                                } else {
+                                  setSelectedColumn(header);
+                                  setShowStylePanel(true);
+                                }
+                              }}
+                            >
+                              <SettingsIcon size={14} />
+                            </button>
+                          )}
+                          {(isCustomize || showFilterRow) && (
+                            <div className={styles.sortIcons}>
+                              <ChevronUp size={12} className={isSortAsc(header) ? styles.sortActive : styles.sortInactive} />
+                              <ChevronDown size={12} className={isSortDesc(header) ? styles.sortActive : styles.sortInactive} style={{ marginTop: '-3px' }} />
+                            </div>
                           )}
                         </div>
                       </div>


### PR DESCRIPTION
## Summary
- allow column sort toggling when filters are displayed, even without customize mode
- show sort indicators when filters or customize mode are active
- add regression test for sorting with filters enabled

## Testing
- `npm run build`
- `npm run lint`
- `npm test`
- `npm pack --dry-run`
- `cd demo && npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b09bbafabc8323affb1338d83724e6