### PR TITLE
feat: add max width setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Notes
 - `title?: string` Optional title displayed in a themed header above the table.
 - `collapsed?: boolean` Render the table initially collapsed with a toggle in the header.
 - `maxHeight?: string` Limit table height (e.g., `'400px'`, `'50vh'`). Use `'unlimited'` for no limit.
+- `maxWidth?: string` Limit table width (e.g., `'400px'`, `'80%'`). Use `'unlimited'` for no limit.
 - `fontSize?: number` Font size for table values in pixels. Default `13`.
 - Theme selection is managed inside the component's settings. Use the Settings panel to cycle themes; the current theme is saved to `localStorage` and included when exporting settings.
 
@@ -114,7 +115,7 @@ Notes
   - Optional `title` shows above the table; optional `collapsed` renders the view initially collapsed with a toggle.
 
 ## Exported/Imported Settings (high‑level)
-- `{ version, theme, columnStyles, columnOrder, hiddenColumns, filters, dropdownFilters, filterMode, showFilterRow, pinnedAnchor, showRowNumbers, customize, tableMaxHeight, fontSize }`
+- `{ version, theme, columnStyles, columnOrder, hiddenColumns, filters, dropdownFilters, filterMode, showFilterRow, pinnedAnchor, showRowNumbers, customize, tableMaxHeight, tableMaxWidth, fontSize }`
 
 ## Resetting Settings
 Call `resetSettings()` to revert the table to its initial configuration. The reset also turns off customize mode (or respects a `customize` value from provided defaults) and returns the applied settings object.

--- a/index.d.ts
+++ b/index.d.ts
@@ -9,6 +9,7 @@ export interface ReactTableCSVProps {
   defaultSettings?: string | null;
   title?: string;
   collapsed?: boolean;
+  maxWidth?: string;
   maxHeight?: string;
   fontSize?: number;
 }

--- a/src/ReactTableCsv.jsx
+++ b/src/ReactTableCsv.jsx
@@ -18,6 +18,7 @@ const ReactTableCSV = ({
   title,
   collapsed: collapsedProp = false,
   maxHeight = 'unlimited',
+  maxWidth = 'unlimited',
   fontSize: fontSizeProp = 13,
 }) => {
   const { originalHeaders, data, error } = useCsvData({ csvString, csvURL, csvData });
@@ -34,6 +35,7 @@ const ReactTableCSV = ({
     customize,
     setCustomize,
     defaultMaxHeight: maxHeight,
+    defaultMaxWidth: maxWidth,
     defaultFontSize: fontSizeProp,
   });
 
@@ -177,7 +179,10 @@ const ReactTableCSV = ({
     return (
       <div
         className={`${styles.root} ${styles[table.currentTheme] || styles.lite}`}
-        style={table.tableMaxHeight === 'unlimited' ? { minHeight: '100vh' } : undefined}
+        style={{
+          ...(table.tableMaxHeight === 'unlimited' ? { minHeight: '100vh' } : {}),
+          ...(table.tableMaxWidth !== 'unlimited' ? { maxWidth: table.tableMaxWidth, margin: '0 auto' } : {}),
+        }}
       >
         <div className={styles.container}>
           <div className={styles.card}>{tableBody}</div>
@@ -189,7 +194,16 @@ const ReactTableCSV = ({
   return (
     <div
       className={styles[table.currentTheme] || styles.lite}
-      style={{ marginBottom: 16, border: '1px solid var(--border)', borderRadius: 6, background: 'var(--surface)', maxWidth: '100%', minWidth: 0, overflowX: 'hidden' }}
+      style={{
+        marginBottom: 16,
+        border: '1px solid var(--border)',
+        borderRadius: 6,
+        background: 'var(--surface)',
+        maxWidth: table.tableMaxWidth === 'unlimited' ? '100%' : table.tableMaxWidth,
+        minWidth: 0,
+        overflowX: 'hidden',
+        ...(table.tableMaxWidth !== 'unlimited' ? { marginLeft: 'auto', marginRight: 'auto' } : {}),
+      }}
     >
       <div
         style={{

--- a/src/__tests__/SettingsPanel.test.jsx
+++ b/src/__tests__/SettingsPanel.test.jsx
@@ -30,6 +30,8 @@ describe('SettingsPanel', () => {
         storageKey="test"
         tableMaxHeight="unlimited"
         setTableMaxHeight={noop}
+        tableMaxWidth="unlimited"
+        setTableMaxWidth={noop}
         fontSize={13}
         setFontSize={noop}
       />

--- a/src/components/SettingsPanel.jsx
+++ b/src/components/SettingsPanel.jsx
@@ -23,6 +23,8 @@ const SettingsPanel = ({
   storageKey,
   tableMaxHeight,
   setTableMaxHeight,
+  tableMaxWidth,
+  setTableMaxWidth,
   fontSize,
   setFontSize,
 }) => {
@@ -96,6 +98,40 @@ const SettingsPanel = ({
             <option value="unlimited">unlimited</option>
             <option value="px">px</option>
             <option value="vh">vh</option>
+          </select>
+        </div>
+        <div className={styles.widthGroup}>
+          <Maximize size={16} />
+          <span className={styles.muted}>Max width:</span>
+          <input
+            type="number"
+            placeholder="unlimited"
+            value={tableMaxWidth === 'unlimited' ? '' : parseInt(tableMaxWidth, 10) || ''}
+            onChange={(e) => {
+              const v = e.target.value;
+              const unit = tableMaxWidth === 'unlimited' ? 'px' : tableMaxWidth.endsWith('%') ? '%' : 'px';
+              if (!v) setTableMaxWidth('unlimited');
+              else setTableMaxWidth(`${v}${unit}`);
+            }}
+            className={styles.widthInput}
+            disabled={tableMaxWidth === 'unlimited'}
+          />
+          <select
+            value={tableMaxWidth === 'unlimited' ? 'unlimited' : tableMaxWidth.endsWith('%') ? '%' : 'px'}
+            onChange={(e) => {
+              const unit = e.target.value;
+              if (unit === 'unlimited') {
+                setTableMaxWidth('unlimited');
+              } else {
+                const num = tableMaxWidth === 'unlimited' ? 0 : parseInt(tableMaxWidth, 10) || 0;
+                setTableMaxWidth(`${num}${unit}`);
+              }
+            }}
+            className={styles.unitSelect}
+          >
+            <option value="unlimited">unlimited</option>
+            <option value="px">px</option>
+            <option value="%">%</option>
           </select>
         </div>
         <div className={styles.widthGroup}>

--- a/src/hooks/__tests__/__snapshots__/settingsUtils.test.js.snap
+++ b/src/hooks/__tests__/__snapshots__/settingsUtils.test.js.snap
@@ -32,6 +32,7 @@ exports[`buildSettings builds settings from state 1`] = `
   "showFilterRow": true,
   "showRowNumbers": true,
   "tableMaxHeight": "500px",
+  "tableMaxWidth": "75%",
   "theme": "dark",
   "version": "0.1",
 }

--- a/src/hooks/__tests__/settingsUtils.test.js
+++ b/src/hooks/__tests__/settingsUtils.test.js
@@ -16,6 +16,7 @@ describe('buildSettings', () => {
       showRowNumbers: true,
       customize: true,
       tableMaxHeight: '500px',
+      tableMaxWidth: '75%',
       fontSize: 14,
     };
     expect(buildSettings(state)).toMatchSnapshot();
@@ -35,6 +36,7 @@ describe('buildSettings', () => {
       showRowNumbers: false,
       customize: false,
       tableMaxHeight: 'unlimited',
+      tableMaxWidth: 'unlimited',
       fontSize: 13,
     };
     const result = buildSettings(state);

--- a/src/hooks/settingsUtils.js
+++ b/src/hooks/settingsUtils.js
@@ -13,6 +13,7 @@ export const buildSettings = ({
   showRowNumbers,
   customize,
   tableMaxHeight,
+  tableMaxWidth,
   fontSize,
 }) => {
   const dropdown = {};
@@ -35,6 +36,7 @@ export const buildSettings = ({
     showRowNumbers,
     customize,
     tableMaxHeight,
+    tableMaxWidth,
     fontSize,
   };
 };

--- a/src/hooks/useTableState.js
+++ b/src/hooks/useTableState.js
@@ -9,6 +9,7 @@ const useTableState = ({
   customize,
   setCustomize,
   defaultMaxHeight = 'unlimited',
+  defaultMaxWidth = 'unlimited',
   defaultFontSize = 13,
 }) => {
   const [currentTheme, setCurrentTheme] = useState('lite');
@@ -28,6 +29,7 @@ const useTableState = ({
   const [pinnedAnchor, setPinnedAnchor] = useState(null);
   const [showRowNumbers, setShowRowNumbers] = useState(false);
   const [tableMaxHeight, setTableMaxHeight] = useState(defaultMaxHeight);
+  const [tableMaxWidth, setTableMaxWidth] = useState(defaultMaxWidth);
   const [fontSize, setFontSize] = useState(defaultFontSize);
   const [tableState, setTableState] = useState({ visibleHeaders: [], rows: [] });
 
@@ -120,10 +122,11 @@ const useTableState = ({
         showFilterRow,
         pinnedAnchor,
         showRowNumbers,
-      customize,
-      tableMaxHeight,
-      fontSize,
-    }),
+        customize,
+        tableMaxHeight,
+        tableMaxWidth,
+        fontSize,
+      }),
     [
       currentTheme,
       columnStyles,
@@ -137,6 +140,7 @@ const useTableState = ({
       showRowNumbers,
       customize,
       tableMaxHeight,
+      tableMaxWidth,
       fontSize,
     ]
   );
@@ -171,6 +175,7 @@ const useTableState = ({
         if (typeof s.customize === 'boolean') setCustomize(s.customize);
         if (typeof s.theme === 'string') setCurrentTheme(s.theme);
         if (typeof s.tableMaxHeight === 'string') setTableMaxHeight(s.tableMaxHeight);
+        if (typeof s.tableMaxWidth === 'string') setTableMaxWidth(s.tableMaxWidth);
         if (typeof s.fontSize === 'number') setFontSize(s.fontSize);
         if (typeof s.editable === 'boolean' && typeof s.customize !== 'boolean')
           setCustomize(s.editable);
@@ -221,13 +226,14 @@ const useTableState = ({
     showRowNumbers,
     customize,
     currentTheme,
+    tableMaxWidth,
     storageKey,
     buildSettings,
   ]);
 
   const resetSettings = () => {
     const initial = defaultSettingsObj
-      ? { tableMaxHeight: defaultMaxHeight, fontSize: defaultFontSize, ...defaultSettingsObj }
+      ? { tableMaxHeight: defaultMaxHeight, tableMaxWidth: defaultMaxWidth, fontSize: defaultFontSize, ...defaultSettingsObj }
       : {
           columnStyles: {},
           columnOrder: originalHeaders,
@@ -241,6 +247,7 @@ const useTableState = ({
           theme: 'lite',
           customize: false,
           tableMaxHeight: defaultMaxHeight,
+          tableMaxWidth: defaultMaxWidth,
           fontSize: defaultFontSize,
         };
 
@@ -297,6 +304,8 @@ const useTableState = ({
     resetSettings,
     tableMaxHeight,
     setTableMaxHeight,
+    tableMaxWidth,
+    setTableMaxWidth,
     fontSize,
     setFontSize,
   };


### PR DESCRIPTION
## Summary
- allow configuring max table width and persist to settings
- expose new `maxWidth` prop and UI control
- document maxWidth option

## Testing
- `npm run build`
- `npm run lint`
- `npm test`
- `npm pack --dry-run`
- `cd demo && npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b09ce2cccc832381ccce776ac4bf99