### PR TITLE
fix: clarify empty catch blocks

### DIFF
--- a/src/ReactDashboardCsv.jsx
+++ b/src/ReactDashboardCsv.jsx
@@ -301,7 +301,9 @@ const ReactDashboardCsv = ({ datasets = {}, views = {}, db = 'duckdb', layout })
                   try {
                     const ds = mergedProps.defaultSettings ? JSON.parse(mergedProps.defaultSettings) : null;
                     if (ds && typeof ds.tableMaxWidth === 'string') return ds.tableMaxWidth;
-                  } catch {}
+                  } catch (err) {
+                    /* ignore parse errors */
+                  }
                   return 'unlimited';
                 };
                 const rawMaxWidth = extractMaxWidth();

--- a/src/__tests__/ReactDashboardCsv.test.jsx
+++ b/src/__tests__/ReactDashboardCsv.test.jsx
@@ -96,7 +96,7 @@ describe('ReactDashboardCSV', () => {
 
     // Enter customize -> settings -> change theme
     fireEvent.click(screen.getByTitle('Toggle customize mode'));
-    fireEvent.click(screen.getByText('Settings'));
+    fireEvent.click(screen.getAllByTitle('Customize this column')[0]);
     fireEvent.click(screen.getByText(/Theme:/)); // cycles to dark per theme order
 
     // Collapse

--- a/src/__tests__/ReactTableCsv.test.jsx
+++ b/src/__tests__/ReactTableCsv.test.jsx
@@ -40,7 +40,7 @@ describe('ReactTableCSV', () => {
     render(<ReactTableCSV csvData={csvData} storageKey={storageKey} />);
 
     fireEvent.click(screen.getByTitle('Toggle customize mode'));
-    fireEvent.click(screen.getByText('Settings'));
+    fireEvent.click(screen.getAllByTitle('Customize this column')[0]);
     fireEvent.click(screen.getByText(/Theme:/));
 
     await waitFor(() => {
@@ -98,7 +98,8 @@ describe('ReactTableCSV', () => {
     const rowsBefore = screen.getAllByRole('row');
     expect(rowsBefore[2]).toHaveTextContent('2');
 
-    fireEvent.click(screen.getByText('id'));
+    const idHeader = screen.getAllByText('id').find(el => el.tagName === 'SPAN');
+    fireEvent.click(idHeader);
 
     const rowsAfter = screen.getAllByRole('row');
     expect(rowsAfter[2]).toHaveTextContent('1');

--- a/src/components/DataTable.jsx
+++ b/src/components/DataTable.jsx
@@ -187,7 +187,9 @@ const DataTable = ({
     try {
       e.preventDefault();
       e.stopPropagation();
-    } catch {}
+    } catch (err) {
+      // Some environments (tests, older browsers) may not support these methods
+    }
     const th = headerRefs.current[col];
     const startWidth = th ? th.getBoundingClientRect().width : 0;
     setResizing({ col, startX: e.clientX, startWidth });

--- a/src/components/SettingsPanel.jsx
+++ b/src/components/SettingsPanel.jsx
@@ -37,12 +37,14 @@ const SettingsPanel = ({
     try {
       const json = JSON.stringify(buildSettings(), null, 2);
       if (navigator.clipboard && navigator.clipboard.writeText) {
-        navigator.clipboard.writeText(json).catch(() => {});
+        navigator.clipboard.writeText(json).catch(() => {
+          // Ignore clipboard errors (e.g., unsupported browser)
+        });
       }
       setExportText(json);
       setShowExport(true);
     } catch {
-      /* ignore */
+      // JSON.stringify may fail for circular structures
     }
   };
 
@@ -109,7 +111,18 @@ const SettingsPanel = ({
               onFocus={(e) => e.currentTarget.select()}
             />
             <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 8, marginTop: 8 }}>
-              <button className={styles.btn} onClick={() => { try { exportTextareaRef.current?.select(); } catch {} }}>Select All</button>
+              <button
+                className={styles.btn}
+                onClick={() => {
+                  try {
+                    exportTextareaRef.current?.select();
+                  } catch (err) {
+                    // Ignore selection issues (e.g., sandboxed iframes)
+                  }
+                }}
+              >
+                Select All
+              </button>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- document why some event helpers are ignored during resize
- add context for clipboard and selection errors in settings panel
- adjust tests to open settings via icon-only buttons

## Testing
- `npm run lint`
- `npm test`
- `npm run build`
- `npm pack --dry-run`
- `cd demo && npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b109400b6c8323a158ba430bae53c9