### PR TITLE
feat: display row info in header

### DIFF
--- a/src/ReactTableCsv.jsx
+++ b/src/ReactTableCsv.jsx
@@ -124,31 +124,41 @@ const ReactTableCSV = ({
   }
   const tableBody = (
     <>
-      {!title && (
-        <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 8, marginBottom: 8 }}>
-          <button
-            onClick={() => table.setShowFilterRow(!table.showFilterRow)}
-            className={`${styles.iconBtn} ${styles.headerBtn} ${table.showFilterRow ? styles.iconBtnActive : ''}`}
-            title={table.showFilterRow ? 'Hide Filters' : 'Show Filters'}
+        {!title && (
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'space-between',
+              gap: 8,
+              marginBottom: 8,
+            }}
           >
-            <Filter size={16} />
-          </button>
-          <button
-            onClick={() => setCustomize((c) => !c)}
-            className={`${styles.iconBtn} ${styles.headerBtn} ${customize ? styles.iconBtnActive : ''}`}
-            title="Toggle customize mode"
-          >
-            <SettingsIcon size={16} />
-          </button>
-        </div>
-      )}
+            <div className={styles.info}>
+              Showing {table.tableState.rows.length} of {data.length} rows | {table.tableState.visibleHeaders.length} of {originalHeaders.length} columns
+            </div>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+              <button
+                onClick={() => table.setShowFilterRow(!table.showFilterRow)}
+                className={`${styles.iconBtn} ${styles.headerBtn} ${table.showFilterRow ? styles.iconBtnActive : ''}`}
+                title={table.showFilterRow ? 'Hide Filters' : 'Show Filters'}
+              >
+                <Filter size={16} />
+              </button>
+              <button
+                onClick={() => setCustomize((c) => !c)}
+                className={`${styles.iconBtn} ${styles.headerBtn} ${customize ? styles.iconBtnActive : ''}`}
+                title="Toggle customize mode"
+              >
+                <SettingsIcon size={16} />
+              </button>
+            </div>
+          </div>
+        )}
 
       {customize && (
         <Toolbar
           {...table}
-          tableState={table.tableState}
-          dataCount={data.length}
-          headersCount={originalHeaders.length}
           handleCopyUrl={handleCopyUrl}
           handleCopyMarkdown={handleCopyMarkdown}
           handleCopyCsv={handleCopyCsv}
@@ -205,42 +215,45 @@ const ReactTableCSV = ({
         ...(table.tableMaxWidth !== 'unlimited' ? { marginLeft: 'auto', marginRight: 'auto' } : {}),
       }}
     >
-      <div
-        style={{
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'space-between',
-          padding: '8px 12px',
-          background: 'var(--control-bg)',
-          borderBottom: '1px solid var(--border)',
-          color: 'var(--text)',
-        }}
-      >
-        <div style={{ fontWeight: 600 }}>{title}</div>
-        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-          <button
-            onClick={() => table.setShowFilterRow(!table.showFilterRow)}
-            className={`${styles.iconBtn} ${styles.headerBtn} ${table.showFilterRow ? styles.iconBtnActive : ''}`}
-            title={table.showFilterRow ? 'Hide Filters' : 'Show Filters'}
-          >
-            <Filter size={16} />
-          </button>
-          <button
-            onClick={() => setCustomize((c) => !c)}
-            className={`${styles.iconBtn} ${styles.headerBtn} ${customize ? styles.iconBtnActive : ''}`}
-            title="Toggle customize mode"
-          >
-            <SettingsIcon size={16} />
-          </button>
-          <button
-            onClick={() => setCollapsed((c) => !c)}
-            className={`${styles.iconBtn} ${styles.headerBtn}`}
-            title={collapsed ? 'Expand' : 'Collapse'}
-          >
-            {collapsed ? <Plus size={16} /> : <Minus size={16} />}
-          </button>
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            padding: '8px 12px',
+            background: 'var(--control-bg)',
+            borderBottom: '1px solid var(--border)',
+            color: 'var(--text)',
+          }}
+        >
+          <div style={{ fontWeight: 600 }}>{title}</div>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+            <div className={styles.info}>
+              Showing {table.tableState.rows.length} of {data.length} rows | {table.tableState.visibleHeaders.length} of {originalHeaders.length} columns
+            </div>
+            <button
+              onClick={() => table.setShowFilterRow(!table.showFilterRow)}
+              className={`${styles.iconBtn} ${styles.headerBtn} ${table.showFilterRow ? styles.iconBtnActive : ''}`}
+              title={table.showFilterRow ? 'Hide Filters' : 'Show Filters'}
+            >
+              <Filter size={16} />
+            </button>
+            <button
+              onClick={() => setCustomize((c) => !c)}
+              className={`${styles.iconBtn} ${styles.headerBtn} ${customize ? styles.iconBtnActive : ''}`}
+              title="Toggle customize mode"
+            >
+              <SettingsIcon size={16} />
+            </button>
+            <button
+              onClick={() => setCollapsed((c) => !c)}
+              className={`${styles.iconBtn} ${styles.headerBtn}`}
+              title={collapsed ? 'Expand' : 'Collapse'}
+            >
+              {collapsed ? <Plus size={16} /> : <Minus size={16} />}
+            </button>
+          </div>
         </div>
-      </div>
       <div style={{ padding: 8, display: collapsed ? 'none' : 'block', maxWidth: '100%', minWidth: '320px', overflowX: 'hidden' }}>
         <div className={styles.root} style={{ minHeight: 0 }}>
           <div className={styles.container}>

--- a/src/__tests__/ReactTableCsv.test.jsx
+++ b/src/__tests__/ReactTableCsv.test.jsx
@@ -5,7 +5,7 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import ReactTableCSV from '../ReactTableCsv';
 
 describe('ReactTableCSV', () => {
-  it('shows row and column info only in customize mode', () => {
+  it('displays row and column info in the header', () => {
     const csvData = {
       headers: ['id', 'name'],
       data: [
@@ -15,12 +15,6 @@ describe('ReactTableCSV', () => {
     };
 
     render(<ReactTableCSV csvData={csvData} title="Sample" />);
-
-    expect(
-      screen.queryByText('Showing 2 of 2 rows | 2 of 2 columns')
-    ).not.toBeInTheDocument();
-
-    fireEvent.click(screen.getByTitle('Toggle customize mode'));
 
     expect(
       screen.getByText('Showing 2 of 2 rows | 2 of 2 columns')

--- a/src/components/Toolbar.jsx
+++ b/src/components/Toolbar.jsx
@@ -9,9 +9,6 @@ const Toolbar = ({
   handleCopyMarkdown,
   handleCopyCsv,
   handleDownload,
-  tableState,
-  dataCount,
-  headersCount,
 }) => {
   return (
     <div className={styles.controls}>
@@ -44,10 +41,6 @@ const Toolbar = ({
           <Download size={18} />
           Download CSV
         </button>
-      </div>
-
-      <div className={styles.info}>
-        Showing {tableState.rows.length} of {dataCount} rows | {tableState.visibleHeaders.length} of {headersCount} columns
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- move row/column count label from customization toolbar to table header
- adjust toolbar props and tests accordingly

## Testing
- `npm run build`
- `npm run lint`
- `npm test`
- `npm pack --dry-run`
- `cd demo && npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b3ce850f108323b7c13a2ea283a04d