### PR TITLE
fix: ensure consistent zebra row styling

### DIFF
--- a/src/ReactTableCsv.module.css
+++ b/src/ReactTableCsv.module.css
@@ -260,11 +260,9 @@
 .textFilter { flex: 1; min-width: 0; padding: 6px 8px; border: 1px solid var(--border); border-radius: 8px; font-size: 13px; background: var(--surface); color: var(--text); }
 
 .row { background: var(--surface); border-bottom: 1px solid var(--border); transition: background 0.2s ease; }
-.row:nth-child(even) { background: var(--surface-alt); }
 .row:hover { background: var(--row-hover); }
 .cell { padding: 6px 10px; font-size: 13px; line-height: 1.25; background: inherit; }
 .stickyCell { position: sticky; left: 0; z-index: 3; background: var(--surface); }
-.row:nth-child(even) .stickyCell { background: var(--surface-alt); }
 
 .rowAlt { background: var(--surface-alt); }
 .rowAlt .stickyCell { background: var(--surface-alt); }

--- a/src/components/DataTable.jsx
+++ b/src/components/DataTable.jsx
@@ -1271,8 +1271,10 @@ const DataTable = ({
                     {(() => {
                       const rows = sortRows([...g.rows], visibleHeaders, columnStyles);
                       return rows;
-                    })().map((row, index) => (
-                      <tr key={row._id || row._gid || index} className={styles.row}>
+                    })().map((row, index) => {
+                      const alt = index % 2 === 1;
+                      return (
+                        <tr key={row._id || row._gid || index} className={`${styles.row} ${alt ? styles.rowAlt : ''}`}>
                         {showRowNumbers && (
                           <td
                             className={`${styles.cell} ${styles.stickyCell} ${styles.rowNoCell}`}
@@ -1295,8 +1297,9 @@ const DataTable = ({
                             </div>
                           </td>
                         ))}
-                      </tr>
-                    ))}
+                        </tr>
+                      );
+                    })}
                   </tbody>
                 </table>
               </div>


### PR DESCRIPTION
## Summary
- maintain zebra stripe classes for all DataTable rows
- drop nth-child styling and rely on explicit rowAlt class

## Testing
- `npm run build`
- `npm run lint`
- `npm test`
- `npm pack --dry-run`
- `cd demo && npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b3d386ad0483239c0f7c792f2fd3c0